### PR TITLE
Copy DOM modules from purescript-angular

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2014 PureScript
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), in the Software without restriction, including without
+limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to
+whom the Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -11,4 +11,35 @@
     data NodeList :: *
 
 
+## Module DOM.Event
+
+### Types
+
+    type Event  = { keyCode :: Number }
+
+
+## Module DOM.Node
+
+### Values
+
+    focus :: forall e. Node -> Eff (dom :: DOM | e) Unit
+
+
+## Module DOM.Types
+
+### Types
+
+    data ArrayBuffer :: *
+
+    data Blob :: *
+
+    data Document :: *
+
+    data MozBlob :: *
+
+    data MozChunkedArrayBuffer :: *
+
+    data MozChunkedText :: *
+
+
 

--- a/src/DOM/Event.purs
+++ b/src/DOM/Event.purs
@@ -1,0 +1,4 @@
+module DOM.Event where
+
+-- | TODO
+type Event = { keyCode :: Number }

--- a/src/DOM/Node.purs
+++ b/src/DOM/Node.purs
@@ -1,0 +1,12 @@
+module DOM.Node where
+
+import Control.Monad.Eff
+import DOM
+
+foreign import focus
+  " function focus(node) { \
+  \   return function(){ \
+  \     return node.focus(); \
+  \   }; \
+  \ }"
+  :: forall e. Node -> Eff (dom :: DOM | e) Unit

--- a/src/DOM/Types.purs
+++ b/src/DOM/Types.purs
@@ -1,0 +1,20 @@
+module DOM.Types
+  ( ArrayBuffer()
+  , Blob()
+  , Document()
+  , MozBlob()
+  , MozChunkedText()
+  , MozChunkedArrayBuffer()
+  ) where
+
+foreign import data ArrayBuffer :: *
+
+foreign import data Blob :: *
+
+foreign import data Document :: *
+
+foreign import data MozBlob :: *
+
+foreign import data MozChunkedText :: *
+
+foreign import data MozChunkedArrayBuffer :: *


### PR DESCRIPTION
Basically unmodified (aside from removing redundant definitions) from https://github.com/purescript-contrib/purescript-angular/tree/master/src/DOM.  This way purescript-angular could use this package, so DOM bindings can be unified and worked on in one place.

I am not the original author, @ethul is, so I've also copied over his license, given that there wasn't one here already.
