### PR TITLE
Add `CSSStyleDeclaration` type

### DIFF
--- a/docs/DOM.md
+++ b/docs/DOM.md
@@ -32,4 +32,12 @@ data NodeList :: *
 
 General type for DOM node lists.
 
+#### `CSSStyleDeclaration`
+
+``` purescript
+data CSSStyleDeclaration :: *
+```
+
+General type for CSS style declarations.
+
 

--- a/src/DOM.purs
+++ b/src/DOM.purs
@@ -11,3 +11,6 @@ foreign import data Node :: *
 
 -- | General type for DOM node lists.
 foreign import data NodeList :: *
+
+-- | General type for CSS style declarations.
+foreign import data CSSStyleDeclaration :: *


### PR DESCRIPTION
I've found myself defining this type in a few projects, and wondered if it belonged here. Technically it's part of the CSSOM, so maybe not?

This type is used by a couple of web APIs that I can think of: `HTMLElement.style` and `window.getComputedStyle`.
