### PR TITLE
Add setAttribute and getAttribute

### DIFF
--- a/src/DOM/Node/Element.js
+++ b/src/DOM/Node/Element.js
@@ -69,3 +69,22 @@ exports.getElementsByClassName = function (classNames) {
     };
   };
 };
+
+exports.setAttribute = function (name) {
+  return function (value) {
+    return function (element) {
+      return function () {
+        element.setAttribute(name, value);
+        return {};
+      };
+    };
+  };
+};
+
+exports.getAttribute = function (name) {
+  return function (element) {
+    return function () {
+      return element.getAttribute(name);
+    };
+  };
+};

--- a/src/DOM/Node/Element.purs
+++ b/src/DOM/Node/Element.purs
@@ -20,3 +20,6 @@ foreign import setClassName :: forall eff. String -> Element -> Eff (dom :: DOM 
 foreign import getElementsByTagName :: forall eff. String -> Element -> Eff (dom :: DOM | eff) HTMLCollection
 foreign import getElementsByTagNameNS :: forall eff. Nullable String -> String -> Element -> Eff (dom :: DOM | eff) HTMLCollection
 foreign import getElementsByClassName :: forall eff. String -> Element -> Eff (dom :: DOM | eff) HTMLCollection
+
+foreign import setAttribute :: forall eff. String -> String -> Element -> Eff (dom :: DOM | eff) String
+foreign import getAttribute :: forall eff. String -> Element -> Eff (dom :: DOM | eff) (Nullable String)


### PR DESCRIPTION
This commit adds setAttribute and getAttribute functions,
without introducing Attr type.

However, it should be noted that Attr IDL can be easily
captured with native purescript types and possibly it'll
be a better idea than having functions that work with
Attrs be stringly-typed.

This code have been "hand-tested" with the following
[snippet](https://github.com/manpages/purelace/blob/9b0e4ad8298a2c619b16ffe536669aee960d3553/src/Main.purs#L70-L73), which — indeed — prints `true`
in console.
