### PR TITLE
Avoid duplicate rows / eventListener

### DIFF
--- a/src/DOM/Event/EventTarget.purs
+++ b/src/DOM/Event/EventTarget.purs
@@ -13,15 +13,15 @@ import DOM.Event.Types
 foreign import data EventListener :: # ! -> *
 
 -- | Creates an EventListener from a normal PureScript Eff function.
-foreign import eventListener :: forall eff a. (Event -> Eff (dom :: DOM | eff) a) -> EventListener (dom :: DOM | eff)
+foreign import eventListener :: forall eff a. (Event -> Eff eff a) -> EventListener eff
 
 -- | Adds a listener to an event target. The boolean argument indicates whether
 -- | the listener should be added for the "capture" phase.
-foreign import addEventListener :: forall eff. EventType -> EventListener eff -> Boolean -> EventTarget -> Eff (dom :: DOM | eff) Unit
+foreign import addEventListener :: forall eff. EventType -> EventListener (dom :: DOM | eff) -> Boolean -> EventTarget -> Eff (dom :: DOM | eff) Unit
 
 -- | Removes a listener to an event target. The boolean argument indicates
 -- | whether the listener should be removed for the "capture" phase.
-foreign import removeEventListener :: forall eff. EventType -> EventListener eff -> Boolean -> EventTarget -> Eff (dom :: DOM | eff) Unit
+foreign import removeEventListener :: forall eff. EventType -> EventListener (dom :: DOM | eff) -> Boolean -> EventTarget -> Eff (dom :: DOM | eff) Unit
 
 -- | Dispatches an event from an event target.
 foreign import dispatchEvent :: forall eff. Event -> EventTarget -> Eff (dom :: DOM, err :: EXCEPTION | eff) Boolean


### PR DESCRIPTION
Thanks for fixing #12 , didn't get around to test before making PR. But I think despite mentioning it you introduced a duplicate row issue with `DOM`, `EventListener` needs to include or not include `DOM` everywhere or it gets doubled up.
