### PR TITLE
Add missing Element-Attr API functions, add Attr type.

### DIFF
--- a/src/DOM/Node/Attr.purs
+++ b/src/DOM/Node/Attr.purs
@@ -1,0 +1,64 @@
+module DOM.Node.Attr where
+
+import Prelude
+
+import           Data.Nullable
+import           Data.Maybe (Maybe(..))
+import           Control.Monad.Eff (Eff())
+
+import           DOM
+import           DOM.Node.Types
+import qualified DOM.Node.Element as E
+
+attr :: String -> String -> Attr
+attr x y = { localName: x, value: y }
+
+attrNS :: String -> String -> Maybe String -> Maybe String -> AttrNS
+attrNS ln v ns pr = { localName       : ln
+                    , value           : v
+                    , namespaceURI    : toNullable ns
+                    , prefix          : toNullable pr
+                    , legacyName      : ln
+                    , legacySpecified : true }
+
+setAttribute :: forall eff. Attr -> Element -> Eff (dom :: DOM | eff) Attr
+setAttribute x y = E.setAttribute x.localName x.value y >> return x
+
+setAttributeNS :: forall eff. AttrNS -> Element -> Eff (dom :: DOM | eff) AttrNS
+setAttributeNS x y = E.setAttributeNS x.namespaceURI x.localName x.value y >> return x
+
+getAttribute :: forall eff. Attr -> Element -> Eff (dom :: DOM | eff) (Nullable Attr)
+getAttribute x y = E.getAttribute x.localName y >>=
+                     \v -> return $
+                       fmapNull (\v1 -> { localName: x.localName, value: v1 }) v
+
+getAttributeNS :: forall eff. AttrNS -> Element -> Eff (dom :: DOM | eff) (Nullable AttrNS)
+getAttributeNS x y = E.getAttributeNS x.namespaceURI x.localName y >>=
+                       \v -> return $
+                          fmapNull (\v1 -> { localName        : x.localName
+                                           , value            : v1
+                                           , legacyName       : x.legacyName
+                                           , namespaceURI     : x.namespaceURI
+                                           , prefix           : x.prefix
+                                           , legacySpecified  : x.legacySpecified }) v
+
+hasAttribute :: forall eff. Attr -> Element -> Eff (dom :: DOM | eff) Boolean
+hasAttribute x y = E.hasAttribute x.localName y
+
+hasAttributeNS :: forall eff. AttrNS -> Element -> Eff (dom :: DOM | eff) Boolean
+hasAttributeNS x y = E.hasAttributeNS x.namespaceURI x.localName y
+
+removeAttribute :: forall eff. Attr -> Element -> Eff (dom :: DOM | eff) Attr
+removeAttribute x y = E.removeAttribute x.localName y >> return x
+
+removeAttributeNS :: forall eff. AttrNS -> Element -> Eff (dom :: DOM | eff) AttrNS
+removeAttributeNS x y = E.removeAttributeNS x.namespaceURI x.localName y >> return x
+
+fmapNull :: forall a b. (a -> b) -> (Nullable a) -> (Nullable b)
+fmapNull f x = g f $ toMaybe x
+  where
+    g f Nothing  = toNullable Nothing
+    g f (Just v) = toNullable $ Just (f v)
+
+(>>) :: forall a b m. (Monad m) => m a -> m b -> m b
+(>>) x y = x >>= \_ -> y

--- a/src/DOM/Node/Element.js
+++ b/src/DOM/Node/Element.js
@@ -81,10 +81,71 @@ exports.setAttribute = function (name) {
   };
 };
 
+exports.setAttributeNS = function (ns) {
+  return function (localName) {
+    return function (value) {
+      return function (element) {
+        return function () {
+          element.setAttribute(localName, value);
+          return {};
+        };
+      };
+    };
+  };
+};
+
 exports.getAttribute = function (name) {
   return function (element) {
     return function () {
       return element.getAttribute(name);
+    };
+  };
+};
+
+exports.getAttributeNS = function (ns) {
+  return function (localName) {
+    return function (element) {
+      return function () {
+        return element.getAttribute(localName);
+      };
+    };
+  };
+};
+
+exports.hasAttribute = function (name) {
+  return function (element) {
+    return function () {
+      return element.hasAttribute(name);
+    };
+  };
+};
+
+exports.hasAttributeNS = function (ns) {
+  return function (localName) {
+    return function (element) {
+      return function () {
+        return element.hasAttribute(localName);
+      };
+    };
+  };
+};
+
+exports.removeAttribute = function (name) {
+  return function (element) {
+    return function () {
+      element.removeAttribute(name);
+      return {};
+    };
+  };
+};
+
+exports.removeAttributeNS = function (ns) {
+  return function (name) {
+    return function (element) {
+      return function () {
+        element.removeAttribute(name);
+        return {};
+      };
     };
   };
 };

--- a/src/DOM/Node/Element.purs
+++ b/src/DOM/Node/Element.purs
@@ -22,4 +22,10 @@ foreign import getElementsByTagNameNS :: forall eff. Nullable String -> String -
 foreign import getElementsByClassName :: forall eff. String -> Element -> Eff (dom :: DOM | eff) HTMLCollection
 
 foreign import setAttribute :: forall eff. String -> String -> Element -> Eff (dom :: DOM | eff) String
+foreign import setAttributeNS :: forall eff. (Nullable String) -> String -> String -> Element -> Eff (dom :: DOM | eff) String
 foreign import getAttribute :: forall eff. String -> Element -> Eff (dom :: DOM | eff) (Nullable String)
+foreign import getAttributeNS :: forall eff. (Nullable String) -> String -> Element -> Eff (dom :: DOM | eff) (Nullable String)
+foreign import hasAttribute :: forall eff. String -> Element -> Eff (dom :: DOM | eff) Boolean
+foreign import hasAttributeNS :: forall eff. (Nullable String) -> String -> Element -> Eff (dom :: DOM | eff) Boolean
+foreign import removeAttribute :: forall eff. String -> Element -> Eff (dom :: DOM | eff) String
+foreign import removeAttributeNS :: forall eff. (Nullable String) -> String -> Element -> Eff (dom :: DOM | eff) String

--- a/src/DOM/Node/Types.purs
+++ b/src/DOM/Node/Types.purs
@@ -3,6 +3,7 @@ module DOM.Node.Types where
 
 import Prelude
 
+import Data.Nullable (Nullable())
 import qualified Unsafe.Coerce as U
 
 foreign import data Node :: *
@@ -73,3 +74,12 @@ foreign import data DocumentType :: *
 
 documentTypeToNode :: DocumentType -> Node
 documentTypeToNode = U.unsafeCoerce
+
+type Attr = { localName :: String
+            , value     :: String  }
+type AttrNS = { localName       :: String
+              , value           :: String
+              , legacyName      :: String
+              , namespaceURI    :: Nullable String
+              , prefix          :: Nullable String
+              , legacySpecified :: Boolean }


### PR DESCRIPTION
This commit also adds natively-typed API to work with attributes.

Notice that here we also take a liberty of explicitly marking legacy and
nonsense-fields of Attr IDL as `legacy` instead of IDL names of those.

Again, a ridiculously stupid, yet somewhat complete [test suite](https://github.com/manpages/purelace/blob/master/src/Main.purs#L131-L160) is attached to PR.

I don't expect this PR to get merged right away, instead I'd like to hear
opinions regarding what to do with this code and Attr API.
