### PR TITLE
Fix setTextContent type and FFI code

### DIFF
--- a/docs/DOM/Node/Node.md
+++ b/docs/DOM/Node/Node.md
@@ -139,7 +139,7 @@ cases.
 #### `setTextContent`
 
 ``` purescript
-setTextContent :: forall eff. Node -> Eff (dom :: DOM | eff) Unit
+setTextContent :: forall eff. String -> Node -> Eff (dom :: DOM | eff) Unit
 ```
 
 If the node type is document fragment, element, text, processing

--- a/src/DOM/Node/Node.js
+++ b/src/DOM/Node/Node.js
@@ -59,7 +59,7 @@ exports.textContent = getEffProp("textContent");
 exports.setTextContent = function (value) {
   return function (node) {
     return function () {
-      node.nodeValue = value;
+      node.textContent = value;
       return {};
     };
   };

--- a/src/DOM/Node/Node.purs
+++ b/src/DOM/Node/Node.purs
@@ -72,7 +72,7 @@ foreign import textContent :: forall eff. Node -> Eff (dom :: DOM | eff) String
 -- | If the node type is document fragment, element, text, processing
 -- | instruction, or comment this allows the node's data to be changed, or has
 -- | no effect in all other cases.
-foreign import setTextContent :: forall eff. Node -> Eff (dom :: DOM | eff) Unit
+foreign import setTextContent :: forall eff. String -> Node -> Eff (dom :: DOM | eff) Unit
 
 -- | Removes empty text nodes and then combines any remaining text nodes that
 -- | are contiguous.


### PR DESCRIPTION
I overlooked this in the last PR. The type of `setTextContent` was still wrong. It's implementation too :smile: 
