### PR TITLE
DOM.HTML.Location: add setters; assign, replace, reload (#35)

### DIFF
--- a/src/DOM/HTML/Location.js
+++ b/src/DOM/HTML/Location.js
@@ -9,9 +9,25 @@ exports.hash = function (location) {
   };
 };
 
+exports.setHash = function (location) {
+  return function (hash) {
+    return function () {
+      location.hash = hash;
+    };
+  };
+};
+
 exports.host = function (location) {
   return function () {
     return location.host;
+  };
+};
+
+exports.setHost = function (location) {
+  return function (host) {
+    return function () {
+      location.host = host;
+    };
   };
 };
 
@@ -21,9 +37,25 @@ exports.hostname = function (location) {
   };
 };
 
+exports.setHostname = function (location) {
+  return function (hostname) {
+    return function () {
+      location.hostname = hostname;
+    };
+  };
+};
+
 exports.href = function (location) {
   return function () {
     return location.href;
+  };
+};
+
+exports.setHref = function (location) {
+  return function (href) {
+    return function () {
+      location.href = href;
+    };
   };
 };
 
@@ -33,9 +65,25 @@ exports.origin = function (location) {
   };
 };
 
+exports.setOrigin = function (location) {
+  return function (origin) {
+    return function () {
+      location.origin = origin;
+    };
+  };
+};
+
 exports.pathname = function (location) {
   return function () {
     return location.pathname;
+  };
+};
+
+exports.setPathname = function (location) {
+  return function (pathname) {
+    return function () {
+      location.pathname = pathname;
+    };
   };
 };
 
@@ -45,14 +93,62 @@ exports.port = function (location) {
   };
 };
 
+exports.setPort = function (location) {
+  return function (port) {
+    return function () {
+      location.port = port;
+    };
+  };
+};
+
 exports.protocol = function (location) {
   return function () {
     return location.protocol;
   };
 };
 
+exports.setProtocol = function (location) {
+  return function (protocol) {
+    return function () {
+      location.protocol = protocol;
+    };
+  };
+};
+
 exports.search = function (location) {
   return function () {
     return location.search;
+  };
+};
+
+exports.setSearch = function (location) {
+  return function (search) {
+    return function () {
+      location.search = search;
+    };
+  };
+};
+
+exports.assign = function (location) {
+  return function (url) {
+    return function () {
+      location.assign(url);
+    };
+  };
+};
+
+exports.replace = function (location) {
+  return function (url) {
+    return function () {
+      location.replace(url);
+    };
+  };
+};
+
+exports.reload = function (location) {
+  return function (args) {
+    return function() {
+      location.reload(args.forceGet);
+    };
   };
 };

--- a/src/DOM/HTML/Location.js
+++ b/src/DOM/HTML/Location.js
@@ -9,8 +9,8 @@ exports.hash = function (location) {
   };
 };
 
-exports.setHash = function (location) {
-  return function (hash) {
+exports.setHash = function (hash) {
+  return function (location) {
     return function () {
       location.hash = hash;
     };
@@ -23,8 +23,8 @@ exports.host = function (location) {
   };
 };
 
-exports.setHost = function (location) {
-  return function (host) {
+exports.setHost = function (host) {
+  return function (location) {
     return function () {
       location.host = host;
     };
@@ -37,8 +37,8 @@ exports.hostname = function (location) {
   };
 };
 
-exports.setHostname = function (location) {
-  return function (hostname) {
+exports.setHostname = function (hostname) {
+  return function (location) {
     return function () {
       location.hostname = hostname;
     };
@@ -51,8 +51,8 @@ exports.href = function (location) {
   };
 };
 
-exports.setHref = function (location) {
-  return function (href) {
+exports.setHref = function (href) {
+  return function (location) {
     return function () {
       location.href = href;
     };
@@ -65,8 +65,8 @@ exports.origin = function (location) {
   };
 };
 
-exports.setOrigin = function (location) {
-  return function (origin) {
+exports.setOrigin = function (origin) {
+  return function (location) {
     return function () {
       location.origin = origin;
     };
@@ -79,8 +79,8 @@ exports.pathname = function (location) {
   };
 };
 
-exports.setPathname = function (location) {
-  return function (pathname) {
+exports.setPathname = function (pathname) {
+  return function (location) {
     return function () {
       location.pathname = pathname;
     };
@@ -93,8 +93,8 @@ exports.port = function (location) {
   };
 };
 
-exports.setPort = function (location) {
-  return function (port) {
+exports.setPort = function (port) {
+  return function (location) {
     return function () {
       location.port = port;
     };
@@ -107,8 +107,8 @@ exports.protocol = function (location) {
   };
 };
 
-exports.setProtocol = function (location) {
-  return function (protocol) {
+exports.setProtocol = function (protocol) {
+  return function (location) {
     return function () {
       location.protocol = protocol;
     };
@@ -121,24 +121,24 @@ exports.search = function (location) {
   };
 };
 
-exports.setSearch = function (location) {
-  return function (search) {
+exports.setSearch = function (search) {
+  return function (location) {
     return function () {
       location.search = search;
     };
   };
 };
 
-exports.assign = function (location) {
-  return function (url) {
+exports.assign = function (url) {
+  return function (location) {
     return function () {
       location.assign(url);
     };
   };
 };
 
-exports.replace = function (location) {
-  return function (url) {
+exports.replace = function (url) {
+  return function (location) {
     return function () {
       location.replace(url);
     };
@@ -146,9 +146,7 @@ exports.replace = function (location) {
 };
 
 exports.reload = function (location) {
-  return function (args) {
-    return function() {
-      location.reload(args.forceGet);
-    };
+  return function() {
+    location.reload();
   };
 };

--- a/src/DOM/HTML/Location.purs
+++ b/src/DOM/HTML/Location.purs
@@ -1,16 +1,62 @@
-module DOM.HTML.Location where
+module DOM.HTML.Location
+  ( hash
+  , setHash
+  , host
+  , setHost
+  , hostname
+  , setHostname
+  , href
+  , setHref
+  , origin
+  , setOrigin
+  , pathname
+  , setPathname
+  , port
+  , setPort
+  , protocol
+  , setProtocol
+  , search
+  , setSearch
+
+  , assign
+  , replace
+  , reload
+  ) where
 
 import Control.Monad.Eff (Eff())
+
+import Prelude
 
 import DOM
 import DOM.HTML.Types
 
 foreign import hash :: forall eff. Location -> Eff (dom :: DOM | eff) String
+foreign import setHash :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
+
 foreign import host :: forall eff. Location -> Eff (dom :: DOM | eff) String
+foreign import setHost :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
+
 foreign import hostname :: forall eff. Location -> Eff (dom :: DOM | eff) String
+foreign import setHostname :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
+
 foreign import href :: forall eff. Location -> Eff (dom :: DOM | eff) String
+foreign import setHref :: forall eff. Location -> String -> Eff (dom :: DOM | eff) String
+
 foreign import origin :: forall eff. Location -> Eff (dom :: DOM | eff) String
+foreign import setOrigin :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
+
 foreign import pathname :: forall eff. Location -> Eff (dom :: DOM | eff) String
+foreign import setPathname :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
+
 foreign import port :: forall eff. Location -> Eff (dom :: DOM | eff) String
+foreign import setPort :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
+
 foreign import protocol :: forall eff. Location -> Eff (dom :: DOM | eff) String
+foreign import setProtocol :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
+
 foreign import search :: forall eff. Location -> Eff (dom :: DOM | eff) String
+foreign import setSearch :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
+
+foreign import assign :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
+foreign import replace :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
+foreign import reload :: forall eff. Location -> { forceGet :: Boolean } -> Eff (dom :: DOM | eff) Unit

--- a/src/DOM/HTML/Location.purs
+++ b/src/DOM/HTML/Location.purs
@@ -31,32 +31,32 @@ import DOM
 import DOM.HTML.Types
 
 foreign import hash :: forall eff. Location -> Eff (dom :: DOM | eff) String
-foreign import setHash :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
+foreign import setHash :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
 
 foreign import host :: forall eff. Location -> Eff (dom :: DOM | eff) String
-foreign import setHost :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
+foreign import setHost :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
 
 foreign import hostname :: forall eff. Location -> Eff (dom :: DOM | eff) String
-foreign import setHostname :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
+foreign import setHostname :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
 
 foreign import href :: forall eff. Location -> Eff (dom :: DOM | eff) String
-foreign import setHref :: forall eff. Location -> String -> Eff (dom :: DOM | eff) String
+foreign import setHref :: forall eff. String -> Location -> Eff (dom :: DOM | eff) String
 
 foreign import origin :: forall eff. Location -> Eff (dom :: DOM | eff) String
-foreign import setOrigin :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
+foreign import setOrigin :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
 
 foreign import pathname :: forall eff. Location -> Eff (dom :: DOM | eff) String
-foreign import setPathname :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
+foreign import setPathname :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
 
 foreign import port :: forall eff. Location -> Eff (dom :: DOM | eff) String
-foreign import setPort :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
+foreign import setPort :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
 
 foreign import protocol :: forall eff. Location -> Eff (dom :: DOM | eff) String
-foreign import setProtocol :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
+foreign import setProtocol :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
 
 foreign import search :: forall eff. Location -> Eff (dom :: DOM | eff) String
-foreign import setSearch :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
+foreign import setSearch :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
 
-foreign import assign :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
-foreign import replace :: forall eff. Location -> String -> Eff (dom :: DOM | eff) Unit
-foreign import reload :: forall eff. Location -> { forceGet :: Boolean } -> Eff (dom :: DOM | eff) Unit
+foreign import assign :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
+foreign import replace :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
+foreign import reload :: forall eff. Location -> Eff (dom :: DOM | eff) Unit


### PR DESCRIPTION
- This is to address #35; @cdepillabout, I hope I haven't stepped on your toes
- also added an explicit export list, which I think is best practice.

@garyb In addition to `replace, assign, reload`, I ended up adding support for all the setters, since I need at least `setHash`, and it felt arbitrary to include only that one. Does that seem OK?
