### PR TITLE
FFI bindings/API for DOMTokenList interface

### DIFF
--- a/src/DOM/Node/DOMTokenList.js
+++ b/src/DOM/Node/DOMTokenList.js
@@ -28,7 +28,7 @@ exports.contains = function(token) {
 exports.add = function(tokens) {
   return function (list) {
     return function () {
-      return list.add.apply(tokens);
+      return list.add.apply(list, tokens);
     }
   }
 }
@@ -36,7 +36,7 @@ exports.add = function(tokens) {
 exports.remove = function(tokens) {
   return function (list) {
     return function () {
-      return list.remove.apply(tokens);
+      return list.remove.apply(list, tokens);
     }
   }
 }

--- a/src/DOM/Node/DOMTokenList.js
+++ b/src/DOM/Node/DOMTokenList.js
@@ -1,0 +1,79 @@
+/* global exports */
+"use strict";
+
+// module DOM.Node.DOMTokenList
+
+exports.length = function (list) {
+  return function () {
+    return list.length;
+  };
+};
+
+exports.item = function (index) {
+  return function (list) {
+    return function () {
+      return list.item(index);
+    };
+  };
+};
+
+exports.contains = function(token) {
+  return function (list) {
+    return function () {
+      return list.contains(token);
+    }
+  }
+}
+
+exports.add = function(tokens) {
+  return function (list) {
+    return function () {
+      return list.add.apply(tokens);
+    }
+  }
+}
+
+exports.remove = function(tokens) {
+  return function (list) {
+    return function () {
+      return list.remove.apply(tokens);
+    }
+  }
+}
+
+exports.toggle = function(token) {
+  return function (list) {
+    return function () {
+      return list.toggle(token);
+    }
+  }
+}
+
+exports.toggleForce = function(token) {
+  return function (force) {
+    return function (list) {
+      return function () {
+        return list.toggle(token, force);
+      }
+    }
+  }
+}
+
+exports.replace = function(token) {
+  return function (newToken) {
+    return function (list) {
+      return function () {
+        return list.replace(token, newToken);
+      }
+    }
+  }
+}
+
+exports.supports = function(token) {
+  return function (list) {
+    return function () {
+      return list.supports(token);
+    }
+  }
+}
+

--- a/src/DOM/Node/DOMTokenList.js
+++ b/src/DOM/Node/DOMTokenList.js
@@ -49,16 +49,6 @@ exports.toggle = function(token) {
   }
 }
 
-exports.toggleForce = function(token) {
-  return function (force) {
-    return function (list) {
-      return function () {
-        return list.toggle(token, force);
-      }
-    }
-  }
-}
-
 exports.replace = function(token) {
   return function (newToken) {
     return function (list) {

--- a/src/DOM/Node/DOMTokenList.purs
+++ b/src/DOM/Node/DOMTokenList.purs
@@ -10,14 +10,33 @@ import DOM
 import DOM.Node.Types
 
 
--- | The number of items in a DOMTokenList.
+-- | The number of tokens in a DOMTokenList.
 foreign import length :: forall eff. DOMTokenList -> Eff (dom :: DOM | eff) Int
 
+-- | The token in a DOMTokenList at the specified index, or null if no such
+-- | token exists.
 foreign import item :: forall eff. Int -> DOMTokenList -> Eff (dom :: DOM | eff) (Nullable String)
-foreign import contains :: forall eff. String -> DOMTokenList -> Eff (dom :: DOM | eff) Int
+
+-- | Test whether or not the DOMTokenList contains the given token.
+foreign import contains :: forall eff. String -> DOMTokenList -> Eff (dom :: DOM | eff) Boolean
+
+-- | Add the given array tokens to the DOMTokenList; duplicate items are
+-- | automatically pruned.
 foreign import add :: forall eff. Array String -> DOMTokenList -> Eff (dom :: DOM | eff) Unit
+
+-- | Remove the given tokens from the DOMTokenList if they exist in it.
 foreign import remove :: forall eff. Array String -> DOMTokenList -> Eff (dom :: DOM | eff) Unit
+
+-- | Toggle the presence of the given token in the DOMTokenList.  Returns
+-- | whether or not the token was originally in the DOMTokenList.
 foreign import toggle :: forall eff. String -> DOMTokenList -> Eff (dom :: DOM | eff) Boolean
-foreign import toggleForce :: forall eff. String -> Boolean -> DOMTokenList -> Eff (dom :: DOM | eff) Boolean
+
+-- | Replaces an occurrence of the token string with the first token.  If the
+-- | first token is not in the DOMTokenList, nothing happens.
 foreign import replace :: forall eff. String -> String -> DOMTokenList -> Eff (dom :: DOM | eff) Unit
+
+-- | Returns whether or not the DOMTokenList supports containing the given token.
+-- |
+-- | TODO: This doesn't actually do this; it actually always returns false,
+-- | unless the token is not valid.  If it isn't, it throws an exception.
 foreign import supports :: forall eff. String -> DOMTokenList -> Eff (dom :: DOM | eff) Boolean

--- a/src/DOM/Node/DOMTokenList.purs
+++ b/src/DOM/Node/DOMTokenList.purs
@@ -1,0 +1,23 @@
+module DOM.Node.DOMTokenList where
+
+import Prelude
+
+import Control.Monad.Eff (Eff())
+
+import Data.Nullable (Nullable())
+
+import DOM
+import DOM.Node.Types
+
+
+-- | The number of items in a DOMTokenList.
+foreign import length :: forall eff. DOMTokenList -> Eff (dom :: DOM | eff) Int
+
+foreign import item :: forall eff. Int -> DOMTokenList -> Eff (dom :: DOM | eff) (Nullable String)
+foreign import contains :: forall eff. String -> DOMTokenList -> Eff (dom :: DOM | eff) Int
+foreign import add :: forall eff. Array String -> DOMTokenList -> Eff (dom :: DOM | eff) Unit
+foreign import remove :: forall eff. Array String -> DOMTokenList -> Eff (dom :: DOM | eff) Unit
+foreign import toggle :: forall eff. String -> DOMTokenList -> Eff (dom :: DOM | eff) Boolean
+foreign import toggleForce :: forall eff. String -> Boolean -> DOMTokenList -> Eff (dom :: DOM | eff) Boolean
+foreign import replace :: forall eff. String -> String -> DOMTokenList -> Eff (dom :: DOM | eff) Unit
+foreign import supports :: forall eff. String -> DOMTokenList -> Eff (dom :: DOM | eff) Boolean

--- a/src/DOM/Node/Element.js
+++ b/src/DOM/Node/Element.js
@@ -88,3 +88,9 @@ exports.getAttribute = function (name) {
     };
   };
 };
+
+exports.classList = function (element) {
+  return function () {
+    return element.classList;
+  };
+};

--- a/src/DOM/Node/Element.purs
+++ b/src/DOM/Node/Element.purs
@@ -25,3 +25,6 @@ foreign import getElementsByClassName :: forall eff. String -> Element -> Eff (d
 
 foreign import setAttribute :: forall eff. String -> String -> Element -> Eff (dom :: DOM | eff) Unit
 foreign import getAttribute :: forall eff. String -> Element -> Eff (dom :: DOM | eff) (Nullable String)
+
+-- | A (mutatable) DOMTokenList representing the classes of the element.
+foreign import classList :: forall eff. Element -> Eff (dom :: DOM | eff) DOMTokenList


### PR DESCRIPTION
Thanks for the great library!  Just adding FFI bindings for the DOM's set-of-strings object, mostly used for dealing with classes of an element -- https://dom.spec.whatwg.org/#interface-domtokenlist

Added some documentation, but I was unsure about some design decisions, because I'm not really too familiar with purescript.  Most of the functions throw a runtime error if invalid strings are passed.  Should I be adding an Error row to the returned Eff, or catch the error in the FFI and return it as a Bool indicating whether or not things were successful?  What is the normal protocol here?
