### PR TITLE
Add HTMLElement properties/methods

### DIFF
--- a/src/DOM/HTML/HTMLElement.js
+++ b/src/DOM/HTML/HTMLElement.js
@@ -1,0 +1,201 @@
+"use strict";
+
+// ----------------------------------------------------------------------------
+
+exports.title = function (elt) {
+  return function () {
+    return elt.title;
+  };
+};
+
+exports.setTitle = function (title) {
+  return function (elt) {
+    return function () {
+      elt.title = title;
+      return {};
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.lang = function (elt) {
+  return function () {
+    return elt.lang;
+  };
+};
+
+exports.setLang = function (lang) {
+  return function (elt) {
+    return function () {
+      elt.lang = lang;
+      return {};
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.dir = function (elt) {
+  return function () {
+    return elt.dir;
+  };
+};
+
+exports.setDir = function (dir) {
+  return function (elt) {
+    return function () {
+      elt.dir = dir;
+      return {};
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.className = function (elt) {
+  return function () {
+    return elt.className;
+  };
+};
+
+exports.setClassName = function (className) {
+  return function (elt) {
+    return function () {
+      elt.className = className;
+      return {};
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.hidden = function (elt) {
+  return function () {
+    return elt.hidden;
+  };
+};
+
+exports.setHidden = function (hidden) {
+  return function (elt) {
+    return function () {
+      elt.hidden = hidden;
+      return {};
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.click = function (elt) {
+  return function () {
+    return elt.click();
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.tabIndex = function (elt) {
+  return function () {
+    return elt.tabIndex;
+  };
+};
+
+exports.setTabIndex = function (tabIndex) {
+  return function (elt) {
+    return function () {
+      elt.tabIndex = tabIndex;
+      return {};
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.hidden = function (elt) {
+  return function () {
+    return elt.hidden;
+  };
+};
+
+exports.setHidden = function (hidden) {
+  return function (elt) {
+    return function () {
+      elt.hidden = hidden;
+      return {};
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.focus = function (elt) {
+  return function () {
+    return elt.focus();
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.blur = function (elt) {
+  return function () {
+    return elt.blur();
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.draggable = function (elt) {
+  return function () {
+    return elt.draggable;
+  };
+};
+
+exports.setDraggable = function (draggable) {
+  return function (elt) {
+    return function () {
+      elt.draggable = draggable;
+      return {};
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.contentEditable = function (elt) {
+  return function () {
+    return elt.contentEditable;
+  };
+};
+
+exports.setContentEditable = function (contentEditable) {
+  return function (elt) {
+    return function () {
+      elt.contentEditable = contentEditable;
+      return {};
+    };
+  };
+};
+
+exports.isContentEditable = function (elt) {
+  return function () {
+    return elt.isContentEditable;
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.spellcheck = function (elt) {
+  return function () {
+    return elt.spellcheck;
+  };
+};
+
+exports.setSpellcheck = function (spellcheck) {
+  return function (elt) {
+    return function () {
+      elt.spellcheck = spellcheck;
+      return {};
+    };
+  };
+};

--- a/src/DOM/HTML/HTMLElement.purs
+++ b/src/DOM/HTML/HTMLElement.purs
@@ -1,0 +1,38 @@
+module DOM.HTML.HTMLElement where
+
+import Prelude
+import Control.Monad.Eff (Eff)
+import DOM (DOM)
+import DOM.HTML.Types (HTMLElement)
+
+foreign import title :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) String
+foreign import setTitle :: forall eff. String -> HTMLElement -> Eff (dom :: DOM | eff) Unit
+
+foreign import lang :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) String
+foreign import setLang :: forall eff. String -> HTMLElement -> Eff (dom :: DOM | eff) Unit
+
+foreign import dir :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) String
+foreign import setDir :: forall eff. String -> HTMLElement -> Eff (dom :: DOM | eff) Unit
+
+foreign import className :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) String
+foreign import setClassName :: forall eff. String -> HTMLElement -> Eff (dom :: DOM | eff) Unit
+
+foreign import hidden :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Boolean
+foreign import setHidden :: forall eff. Boolean -> HTMLElement -> Eff (dom :: DOM | eff) Unit
+
+foreign import tabIndex :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Int
+foreign import setTabIndex :: forall eff. Int -> HTMLElement -> Eff (dom :: DOM | eff) Unit
+
+foreign import draggable :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Boolean
+foreign import setDraggable :: forall eff. Boolean -> HTMLElement -> Eff (dom :: DOM | eff) Unit
+
+foreign import contentEditable :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) String
+foreign import setContentEditable :: forall eff. String -> HTMLElement -> Eff (dom :: DOM | eff) Unit
+foreign import isContentEditable :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Boolean
+
+foreign import spellcheck :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Boolean
+foreign import setSpellcheck :: forall eff. Boolean -> HTMLElement -> Eff (dom :: DOM | eff) Unit
+
+foreign import click :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Unit
+foreign import focus :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Unit
+foreign import blur :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Unit


### PR DESCRIPTION
Per #48.

I worked from the IDL in that comment, removing properties which are inherited from `Element`, and the event handlers per @garyb's comment. Additional omissions (because they seem hard/non-obvious) are

```
readonly attribute DOMStringMap dataset;
attribute HTMLMenuElement contextMenu;
readonly attribute CSSStyleDeclaration style;
```
