### PR TITLE
Handle cases where DataTransfer has a null +files+ slot

### DIFF
--- a/src/DOM/HTML/Event/DragEvent/DataTransfer.js
+++ b/src/DOM/HTML/Event/DragEvent/DataTransfer.js
@@ -1,10 +1,14 @@
 "use strict";
 
-exports.filesImpl = function(just, nothing, dataTransfer) {
-  if (dataTransfer.files) {
-    return just(dataTransfer.files);
-  }
-  else {
-    return nothing;
-  }
+exports.filesImpl = function(just) {
+  return function(nothing) {
+    return function(dataTransfer) {
+      if (dataTransfer.files) {
+	return just(dataTransfer.files);
+      }
+      else {
+	return nothing;
+      }
+    };
+  };
 };

--- a/src/DOM/HTML/Event/DragEvent/DataTransfer.js
+++ b/src/DOM/HTML/Event/DragEvent/DataTransfer.js
@@ -1,13 +1,5 @@
 "use strict";
 
-exports.filesImpl = function (just) {
-  return function (nothing) {
-    return function (dataTransfer) {
-      if (dataTransfer.files) {
-        return just(dataTransfer.files);
-      } else {
-        return nothing;
-      }
-    };
-  };
+exports.filesNullable = function (dataTransfer) {
+  return dataTransfer.files;
 };

--- a/src/DOM/HTML/Event/DragEvent/DataTransfer.js
+++ b/src/DOM/HTML/Event/DragEvent/DataTransfer.js
@@ -1,5 +1,10 @@
 "use strict";
 
-exports.files = function (dataTransfer) {
-  return dataTransfer.files;
+exports.filesImpl = function(just, nothing, dataTransfer) {
+  if (dataTransfer.files) {
+    return just(dataTransfer.files);
+  }
+  else {
+    return nothing;
+  }
 };

--- a/src/DOM/HTML/Event/DragEvent/DataTransfer.js
+++ b/src/DOM/HTML/Event/DragEvent/DataTransfer.js
@@ -1,13 +1,12 @@
 "use strict";
 
-exports.filesImpl = function(just) {
-  return function(nothing) {
-    return function(dataTransfer) {
+exports.filesImpl = function (just) {
+  return function (nothing) {
+    return function (dataTransfer) {
       if (dataTransfer.files) {
-	return just(dataTransfer.files);
-      }
-      else {
-	return nothing;
+        return just(dataTransfer.files);
+      } else {
+        return nothing;
       }
     };
   };

--- a/src/DOM/HTML/Event/DragEvent/DataTransfer.purs
+++ b/src/DOM/HTML/Event/DragEvent/DataTransfer.purs
@@ -5,7 +5,6 @@ module DOM.HTML.Event.DragEvent.DataTransfer
 
 import DOM.File.Types (FileList)
 import Data.Maybe (Maybe(Just, Nothing))
-import Data.Function.Uncurried (Fn3, runFn3)
 
 foreign import data DataTransfer :: *
 
@@ -15,6 +14,9 @@ foreign import data DataTransfer :: *
 -- | It's possible that a drag operation may be null on some browsers. In
 -- | these cases Nothing is returned.
 files :: DataTransfer -> Maybe FileList
-files = runFn3 filesImpl Just Nothing
+files = filesImpl Just Nothing
 
-foreign import filesImpl :: Fn3 (FileList -> Maybe FileList) (Maybe FileList) DataTransfer (Maybe FileList)
+foreign import filesImpl :: (FileList -> Maybe FileList)
+			 -> Maybe FileList
+			 -> DataTransfer
+                         -> Maybe FileList

--- a/src/DOM/HTML/Event/DragEvent/DataTransfer.purs
+++ b/src/DOM/HTML/Event/DragEvent/DataTransfer.purs
@@ -3,20 +3,19 @@ module DOM.HTML.Event.DragEvent.DataTransfer
   , files
   ) where
 
+import Prelude
 import DOM.File.Types (FileList)
-import Data.Maybe (Maybe(Just, Nothing))
+import Data.Maybe (Maybe)
+import Data.Nullable (Nullable, toMaybe)
 
 foreign import data DataTransfer :: *
 
 -- | Contains a list of all the local files available on the data transfer.
 -- | Empty if the drag operation doesn't involve dragging files.
 -- |
--- | It's possible that a drag operation may be null on some browsers. In
--- | these cases Nothing is returned.
+-- | It's possible that a drag operation may have null files, instead of an
+-- | empty file list. In these cases Nothing is returned.
 files :: DataTransfer -> Maybe FileList
-files = filesImpl Just Nothing
+files = toMaybe <$> filesNullable
 
-foreign import filesImpl :: (FileList -> Maybe FileList)
-			 -> Maybe FileList
-			 -> DataTransfer
-                         -> Maybe FileList
+foreign import filesNullable :: DataTransfer -> Nullable FileList

--- a/src/DOM/HTML/Event/DragEvent/DataTransfer.purs
+++ b/src/DOM/HTML/Event/DragEvent/DataTransfer.purs
@@ -1,9 +1,20 @@
-module DOM.HTML.Event.DragEvent.DataTransfer where
+module DOM.HTML.Event.DragEvent.DataTransfer
+  ( DataTransfer
+  , files
+  ) where
 
 import DOM.File.Types (FileList)
+import Data.Maybe (Maybe(Just, Nothing))
+import Data.Function.Uncurried (Fn3, runFn3)
 
 foreign import data DataTransfer :: *
 
 -- | Contains a list of all the local files available on the data transfer.
 -- | Empty if the drag operation doesn't involve dragging files.
-foreign import files :: DataTransfer -> FileList
+-- |
+-- | It's possible that a drag operation may be null on some browsers. In
+-- | these cases Nothing is returned.
+files :: DataTransfer -> Maybe FileList
+files = runFn3 filesImpl Just Nothing
+
+foreign import filesImpl :: Fn3 (FileList -> Maybe FileList) (Maybe FileList) DataTransfer (Maybe FileList)


### PR DESCRIPTION
On firefox, the +files+ property on the DataTransfer object is
intentionally left null from dragover and dragenter events.

Relevant bug: https://bugzilla.mozilla.org/show_bug.cgi?id=640534

Since this isn't likely to be fixed by mozilla, the files function should
account for the possibility of a null.
