### PR TITLE
Initial FileReader bindings

### DIFF
--- a/src/DOM/File/FileReader.js
+++ b/src/DOM/File/FileReader.js
@@ -1,0 +1,36 @@
+/* global FileReader */
+"use strict";
+
+exports.fileReader = function () { return new FileReader(); };
+
+exports.error = function (fr) { return function () { return fr.error; }; };
+
+exports.readyStateImpl = function (fr) { return function () { return fr.readyState; }; };
+
+exports.result = function (fr) { return function () { return fr.result; }; };
+
+exports.abort = function (fr) { return function () { fr.abort(); }; };
+
+exports.readAsText = function (blob) {
+  return function (fr) {
+    return function () {
+      fr.readAsText(blob);
+    };
+  };
+};
+
+exports.readAsArrayBuffer = function (blob) {
+  return function (fr) {
+    return function () {
+      fr.readAsArrayBuffer(blob);
+    };
+  };
+};
+
+exports.readAsDataURL = function (blob) {
+  return function (fr) {
+    return function () {
+      fr.readAsDataURL(blob);
+    };
+  };
+};

--- a/src/DOM/File/FileReader.purs
+++ b/src/DOM/File/FileReader.purs
@@ -1,0 +1,39 @@
+module DOM.File.FileReader
+  ( fileReader
+  , readyState
+  , result
+  , abort
+  , readAsText
+  , readAsArrayBuffer
+  , readAsDataURL
+  ) where
+
+import Prelude
+import Control.Monad.Eff (Eff)
+import DOM (DOM)
+import DOM.File.FileReader.ReadyState (toEnumReadyState, ReadyState)
+import DOM.File.Types (Blob, FileReader)
+import Data.Foreign (Foreign)
+import Data.Maybe (fromJust)
+import Partial.Unsafe (unsafePartial)
+
+foreign import fileReader :: forall eff. Eff (dom :: DOM | eff) FileReader
+
+foreign import error :: forall eff. FileReader -> Eff (dom :: DOM | eff) Foreign
+
+foreign import readyStateImpl :: forall eff. FileReader -> Eff (dom :: DOM | eff) Int
+
+readyState :: forall eff. FileReader -> Eff (dom :: DOM | eff) ReadyState
+readyState fr = do
+  rs <- readyStateImpl fr
+  pure $ unsafePartial $ fromJust $ toEnumReadyState rs
+
+foreign import result :: forall eff. FileReader -> Eff (dom :: DOM | eff) Foreign
+
+foreign import abort :: FileReader -> forall eff. Eff (dom :: DOM | eff) Unit
+
+foreign import readAsText :: Blob -> FileReader -> forall eff. Eff (dom :: DOM | eff) Unit
+
+foreign import readAsArrayBuffer :: Blob -> FileReader -> forall eff. Eff (dom :: DOM | eff) Unit
+
+foreign import readAsDataURL :: Blob -> FileReader -> forall eff. Eff (dom :: DOM | eff) Unit

--- a/src/DOM/File/FileReader/ReadyState.purs
+++ b/src/DOM/File/FileReader/ReadyState.purs
@@ -1,0 +1,46 @@
+module DOM.File.FileReader.ReadyState where
+
+import Prelude
+import Data.Enum (Cardinality(..), class BoundedEnum, defaultPred, defaultSucc, class Enum)
+import Data.Maybe (Maybe(..))
+
+data ReadyState
+  = EMPTY
+  | LOADING
+  | DONE
+
+derive instance eqReadyState :: Eq ReadyState
+derive instance ordReadyState :: Ord ReadyState
+
+instance boundedReadyState :: Bounded ReadyState where
+  bottom = EMPTY
+  top = DONE
+
+instance enumReadyState :: Enum ReadyState where
+  succ = defaultSucc toEnumReadyState fromEnumReadyState
+  pred = defaultPred toEnumReadyState fromEnumReadyState
+
+instance boundedEnumReadyState :: BoundedEnum ReadyState where
+  cardinality = Cardinality 3
+  toEnum = toEnumReadyState
+  fromEnum = fromEnumReadyState
+
+instance showReadyState :: Show ReadyState where
+  show EMPTY = "EMPTY"
+  show LOADING = "LOADING"
+  show DONE = "DONE"
+
+toEnumReadyState :: Int -> Maybe ReadyState
+toEnumReadyState =
+  case _ of
+    0 -> Just EMPTY
+    1 -> Just LOADING
+    2 -> Just DONE
+    _ -> Nothing
+
+fromEnumReadyState :: ReadyState -> Int
+fromEnumReadyState =
+  case _ of
+    EMPTY -> 0
+    LOADING -> 1
+    DONE -> 2

--- a/src/DOM/File/Types.purs
+++ b/src/DOM/File/Types.purs
@@ -1,5 +1,6 @@
 module DOM.File.Types where
 
+import DOM.Event.Types (EventTarget)
 import Unsafe.Coerce (unsafeCoerce)
 
 foreign import data Blob :: *
@@ -11,3 +12,6 @@ foreign import data FileReaderSync :: *
 
 fileToBlob :: File -> Blob
 fileToBlob = unsafeCoerce
+
+fileReaderToEventTarget :: FileReader -> EventTarget
+fileReaderToEventTarget = unsafeCoerce


### PR DESCRIPTION
Not sure if this belongs in here or a separate lib. Either way I'd put some `Aff` layer on top separately.

Unfinished are `error` - is `DOMError`  used somwhere? - and `result` - which I think can be `null | string | ArrayBuffer` 
