### PR TITLE
Fix `clone` and `deepClone`

### DIFF
--- a/src/DOM/Node/Node.js
+++ b/src/DOM/Node/Node.js
@@ -71,13 +71,13 @@ exports.normalize = function (node) {
 
 exports.clone = function (node) {
   return function () {
-    return node.clone(false);
+    return node.cloneNode(false);
   };
 };
 
 exports.deepClone = function (node) {
   return function () {
-    return node.clone(false);
+    return node.cloneNode(true);
   };
 };
 

--- a/src/DOM/Node/Node.purs
+++ b/src/DOM/Node/Node.purs
@@ -86,10 +86,10 @@ foreign import setTextContent :: forall eff.
 foreign import normalize :: forall eff. Node -> Eff (dom :: DOM | eff) Unit
 
 -- | Clones the node without cloning the node's descendants.
-foreign import clone :: forall eff. Node -> Eff (dom :: DOM | eff) Unit
+foreign import clone :: forall eff. Node -> Eff (dom :: DOM | eff) Node
 
 -- | Clones the node and its descendants.
-foreign import deepClone :: forall eff. Node -> Eff (dom :: DOM | eff) Unit
+foreign import deepClone :: forall eff. Node -> Eff (dom :: DOM | eff) Node
 
 -- | Checks whether two nodes are equivalent.
 foreign import isEqualNode :: forall eff.


### PR DESCRIPTION
The FFI `clone` returns a node, so it must be reflected in the type. JS implementation also fixed.