### PR TITLE
Add DOM.HTML.History.

### DIFF
--- a/src/DOM/HTML/History.js
+++ b/src/DOM/HTML/History.js
@@ -1,4 +1,3 @@
-// module DOM.HTML.History
 "use strict";
 
 exports.back = function(history) {

--- a/src/DOM/HTML/History.js
+++ b/src/DOM/HTML/History.js
@@ -1,10 +1,6 @@
 // module DOM.HTML.History
+"use strict";
 
-exports.history = function(window) {
-  return function() {
-    return window.history;
-  };
-}
 exports.back = function(history) {
   return function() {
     return history.back();

--- a/src/DOM/HTML/History.js
+++ b/src/DOM/HTML/History.js
@@ -10,17 +10,17 @@ exports.forward = function(history) {
     return history.forward();
   };
 };
-exports.go = function(history) {
-  return function(delta) {
+exports.go = function(delta) {
+  return function(history) {
     return function() {
       return history.go(delta);
     };
   };
 };
-exports.pushState = function(history) {
-  return function(a) {
-    return function(docTitle) {
-      return function(url) {
+exports.pushState = function(a) {
+  return function(docTitle) {
+    return function(url) {
+      return function(history) {
         return function() {
           return history.pushState(a, docTitle, url);
         };
@@ -28,10 +28,10 @@ exports.pushState = function(history) {
     };
   };
 };
-exports.replaceState = function(history) {
-  return function(a) {
-    return function(docTitle) {
-      return function(url) {
+exports.replaceState = function(a) {
+  return function(docTitle) {
+    return function(url) {
+      return function(history) {
         return function() {
           return history.replaceState(a, docTitle, url);
         };

--- a/src/DOM/HTML/History.js
+++ b/src/DOM/HTML/History.js
@@ -1,0 +1,51 @@
+// module DOM.HTML.History
+
+exports.history = function(window) {
+  return function() {
+    return window.history;
+  };
+}
+exports.back = function(history) {
+  return function() {
+    return history.back();
+  };
+};
+exports.forward = function(history) {
+  return function() {
+    return history.forward();
+  };
+};
+exports.go = function(history) {
+  return function(delta) {
+    return function() {
+      return history.go(delta);
+    };
+  };
+};
+exports.pushState = function(history) {
+  return function(a) {
+    return function(docTitle) {
+      return function(url) {
+        return function() {
+          return history.pushState(a, docTitle, url);
+        };
+      };
+    };
+  };
+};
+exports.replaceState = function(history) {
+  return function(a) {
+    return function(docTitle) {
+      return function(url) {
+        return function() {
+          return history.replaceState(a, docTitle, url);
+        };
+      };
+    };
+  };
+};
+exports.state = function(history) {
+  return function() {
+    return history.state;
+  };
+};

--- a/src/DOM/HTML/History.purs
+++ b/src/DOM/HTML/History.purs
@@ -1,7 +1,8 @@
 module DOM.HTML.History where
 
 import Control.Monad.Eff (Eff)
-import DOM.HTML.Types (HISTORY, History, Window)
+import DOM.HTML.Types (HISTORY, History)
+import Data.Foreign (Foreign)
 import Prelude (Unit)
 
 -- DocumentTitle will set value of `document.title`
@@ -12,6 +13,6 @@ newtype URL = URL String -- Unsure how to better type this.
 foreign import back :: forall e. History -> Eff (history :: HISTORY | e) Unit
 foreign import forward :: forall e. History -> Eff (history :: HISTORY | e) Unit
 foreign import go :: forall e. History -> Delta -> Eff (history :: HISTORY | e) Unit
-foreign import pushState :: forall a e. History -> a -> DocumentTitle -> URL -> Eff (history :: HISTORY | e) Unit
-foreign import replaceState :: forall a e. History -> a -> DocumentTitle -> URL -> Eff (history :: HISTORY | e) Unit
-foreign import state :: forall a e. History -> Eff (history :: HISTORY | e) a
+foreign import pushState :: forall e. History -> Foreign -> DocumentTitle -> URL -> Eff (history :: HISTORY | e) Unit
+foreign import replaceState :: forall e. History -> Foreign -> DocumentTitle -> URL -> Eff (history :: HISTORY | e) Unit
+foreign import state :: forall e. History -> Eff (history :: HISTORY | e) Foreign

--- a/src/DOM/HTML/History.purs
+++ b/src/DOM/HTML/History.purs
@@ -3,16 +3,26 @@ module DOM.HTML.History where
 import Control.Monad.Eff (Eff)
 import DOM.HTML.Types (HISTORY, History)
 import Data.Foreign (Foreign)
-import Prelude (Unit)
+import Data.Newtype (class Newtype)
+import Prelude (class Eq, class Ord, Unit)
 
 -- DocumentTitle will set value of `document.title`
 newtype DocumentTitle = DocumentTitle String
+derive instance eqDocumentTitle :: Eq DocumentTitle
+derive instance ordDocumentTitle :: Ord DocumentTitle
+derive instance newtypeDocumentTitle :: Newtype DocumentTitle _
 newtype Delta = Delta Int
-newtype URL = URL String -- Unsure how to better type this.
+derive instance eqDelta :: Eq Delta
+derive instance ordDelta :: Ord Delta
+derive instance newtypeDelta :: Newtype Delta _
+newtype URL = URL String
+derive instance eqURL :: Eq URL
+derive instance ordURL :: Ord URL
+derive instance newtypeURL :: Newtype URL _
 
 foreign import back :: forall e. History -> Eff (history :: HISTORY | e) Unit
 foreign import forward :: forall e. History -> Eff (history :: HISTORY | e) Unit
-foreign import go :: forall e. History -> Delta -> Eff (history :: HISTORY | e) Unit
-foreign import pushState :: forall e. History -> Foreign -> DocumentTitle -> URL -> Eff (history :: HISTORY | e) Unit
-foreign import replaceState :: forall e. History -> Foreign -> DocumentTitle -> URL -> Eff (history :: HISTORY | e) Unit
+foreign import go :: forall e. Delta -> History -> Eff (history :: HISTORY | e) Unit
+foreign import pushState :: forall e. Foreign -> DocumentTitle -> URL -> History -> Eff (history :: HISTORY | e) Unit
+foreign import replaceState :: forall e. Foreign -> DocumentTitle -> URL -> History -> Eff (history :: HISTORY | e) Unit
 foreign import state :: forall e. History -> Eff (history :: HISTORY | e) Foreign

--- a/src/DOM/HTML/History.purs
+++ b/src/DOM/HTML/History.purs
@@ -1,0 +1,17 @@
+module DOM.HTML.History where
+
+import Control.Monad.Eff (Eff)
+import DOM.HTML.Types (HISTORY, History, Window)
+import Prelude (Unit)
+
+-- DocumentTitle will set value of `document.title`
+newtype DocumentTitle = DocumentTitle String
+newtype Delta = Delta Int
+newtype URL = URL String -- Unsure how to better type this.
+
+foreign import back :: forall e. History -> Eff (history :: HISTORY | e) Unit
+foreign import forward :: forall e. History -> Eff (history :: HISTORY | e) Unit
+foreign import go :: forall e. History -> Delta -> Eff (history :: HISTORY | e) Unit
+foreign import pushState :: forall a e. History -> a -> DocumentTitle -> URL -> Eff (history :: HISTORY | e) Unit
+foreign import replaceState :: forall a e. History -> a -> DocumentTitle -> URL -> Eff (history :: HISTORY | e) Unit
+foreign import state :: forall a e. History -> Eff (history :: HISTORY | e) a

--- a/src/DOM/HTML/Types.purs
+++ b/src/DOM/HTML/Types.purs
@@ -2,10 +2,12 @@
 module DOM.HTML.Types
   ( Navigator
   , Location
+  , History
   , Window
   , ALERT
-  , PROMPT
   , CONFIRM
+  , HISTORY
+  , PROMPT
   , WINDOW
   , windowToEventTarget
   , HTMLDocument
@@ -227,7 +229,11 @@ foreign import data Location :: *
 
 foreign import data Window :: *
 
+foreign import data History :: *
+
 foreign import data ALERT :: !
+
+foreign import data HISTORY :: !
 
 foreign import data PROMPT :: !
 

--- a/src/DOM/HTML/Window.js
+++ b/src/DOM/HTML/Window.js
@@ -18,6 +18,12 @@ exports.location = function (window) {
   };
 };
 
+exports.history = function(window) {
+  return function() {
+    return window.history;
+  };
+}
+
 exports.innerWidth = function (window) {
   return function () {
     return window.innerWidth;

--- a/src/DOM/HTML/Window.js
+++ b/src/DOM/HTML/Window.js
@@ -22,7 +22,7 @@ exports.history = function(window) {
   return function() {
     return window.history;
   };
-}
+};
 
 exports.innerWidth = function (window) {
   return function () {

--- a/src/DOM/HTML/Window.purs
+++ b/src/DOM/HTML/Window.purs
@@ -2,6 +2,7 @@ module DOM.HTML.Window
   ( document
   , navigator
   , location
+  , history
   , innerWidth
   , innerHeight
   , alert
@@ -23,18 +24,20 @@ module DOM.HTML.Window
   , scrollY
   ) where
 
-import Prelude (Unit, (<$>))
-import Data.Maybe (Maybe)
-import Data.Nullable (Nullable, toMaybe)
 import Control.Monad.Eff (Eff)
 import DOM (DOM)
-import DOM.HTML.Types (Window, Location, Navigator, HTMLDocument, ALERT, CONFIRM, PROMPT, WINDOW)
+import DOM.HTML.Types (ALERT, CONFIRM, HISTORY, HTMLDocument, History, Location, Navigator, PROMPT, WINDOW, Window)
+import Data.Maybe (Maybe)
+import Data.Nullable (Nullable, toMaybe)
+import Prelude (Unit, (<$>))
 
 foreign import document :: forall eff. Window -> Eff (dom :: DOM | eff) HTMLDocument
 
 foreign import navigator :: forall eff. Window -> Eff (dom :: DOM | eff) Navigator
 
 foreign import location :: forall eff. Window -> Eff (dom :: DOM | eff) Location
+
+foreign import history :: forall e. Window -> Eff (history :: HISTORY | e) History
 
 foreign import innerWidth :: forall eff. Window -> Eff (dom :: DOM | eff) Int
 


### PR DESCRIPTION
The type signature of `state` might be wrong: `state :: forall a e. History -> Eff (history :: HISTORY | e) a`. I'm not using it, but after some brief exploring of that property I believe it could be *any* shape, so I put `a`. The browser puts one type of data in there, but users could put any type there via `pushState`, per the history spec.

Fixes https://github.com/purescript-contrib/purescript-dom/issues/74