### PR TITLE
Add Blob URL actions `(create|revoke)ObjectURL`

### DIFF
--- a/src/DOM/HTML/Types.purs
+++ b/src/DOM/HTML/Types.purs
@@ -3,6 +3,7 @@ module DOM.HTML.Types
   ( Navigator
   , Location
   , History
+  , URL
   , Window
   , ALERT
   , CONFIRM
@@ -230,6 +231,8 @@ foreign import data Location :: *
 foreign import data Window :: *
 
 foreign import data History :: *
+
+foreign import data URL :: *
 
 foreign import data ALERT :: !
 

--- a/src/DOM/HTML/URL.js
+++ b/src/DOM/HTML/URL.js
@@ -1,0 +1,17 @@
+"use strict";
+
+exports.createObjectURL = function (fileOrBlob) {
+  return function (URL) {
+    return function () {
+      return URL.createObjectURL(fileOrBlob);
+    };
+  };
+};
+
+exports.revokeObjectURL = function (objectURL) {
+  return function (URL) {
+    return function () {
+      return URL.revokeObjectURL(objectURL);
+    };
+  };
+};

--- a/src/DOM/HTML/URL.purs
+++ b/src/DOM/HTML/URL.purs
@@ -1,0 +1,14 @@
+module DOM.HTML.URL
+  ( createObjectURL
+  , revokeObjectURL
+  ) where
+
+import Control.Monad.Eff (Eff)
+import DOM (DOM)
+import DOM.File.Types (File)
+import DOM.HTML.Types (URL)
+import Data.Unit (Unit)
+
+foreign import createObjectURL :: forall eff. File -> URL -> Eff (dom :: DOM | eff) String
+
+foreign import revokeObjectURL :: forall eff. String -> URL -> Eff (dom :: DOM | eff) Unit

--- a/src/DOM/HTML/Window.js
+++ b/src/DOM/HTML/Window.js
@@ -181,3 +181,9 @@ exports.scrollY = function (window) {
     return window.scrollY;
   };
 };
+
+exports.url = function (window) {
+  return function () {
+    return window.URL;
+  };
+};

--- a/src/DOM/HTML/Window.purs
+++ b/src/DOM/HTML/Window.purs
@@ -22,11 +22,12 @@ module DOM.HTML.Window
   , scrollBy
   , scrollX
   , scrollY
+  , url
   ) where
 
 import Control.Monad.Eff (Eff)
 import DOM (DOM)
-import DOM.HTML.Types (ALERT, CONFIRM, HISTORY, HTMLDocument, History, Location, Navigator, PROMPT, WINDOW, Window)
+import DOM.HTML.Types (ALERT, CONFIRM, HISTORY, HTMLDocument, History, Location, Navigator, PROMPT, WINDOW, Window, URL)
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 import Prelude (Unit, (<$>))
@@ -38,6 +39,8 @@ foreign import navigator :: forall eff. Window -> Eff (dom :: DOM | eff) Navigat
 foreign import location :: forall eff. Window -> Eff (dom :: DOM | eff) Location
 
 foreign import history :: forall e. Window -> Eff (history :: HISTORY | e) History
+
+foreign import url :: forall eff. Window -> Eff (dom :: DOM | eff) URL
 
 foreign import innerWidth :: forall eff. Window -> Eff (dom :: DOM | eff) Int
 
@@ -52,7 +55,7 @@ foreign import moveBy :: forall eff. Int -> Int -> Window -> Eff (window :: WIND
 foreign import moveTo :: forall eff. Int -> Int -> Window -> Eff (window :: WINDOW | eff) Unit
 
 open :: forall eff. String -> String -> String -> Window -> Eff (window :: WINDOW | eff) (Maybe Window)
-open window url name features = toMaybe <$> _open window url name features
+open window url' name features = toMaybe <$> _open window url' name features
 
 foreign import _open
   :: forall eff


### PR DESCRIPTION
Blob URL methods are [commonly supported](http://caniuse.com/#search=createobjecturl) and used for crap like getting a URL for use in audio tags when sourced from file inputs and whatnot. I thought it'd be nice to have this in the library since it'll probably be useful for others' <audio> and <video> usages.

(Maybe some things could be renamed to make this less messy, idk)

[My own use:](https://github.com/justinwoo/purescript-web-audio-player-demo/blob/71c22a0/src/Main.purs#L108-L113)

```purescript
              url <- H.liftEff $ url =<< window
              blob <- H.liftEff $ createObjectURL file url
              prevBlob <- H.gets _.file
              case prevBlob of
                Just x ->
                  H.liftEff $ revokeObjectURL (unwrap x) url
```
