### PR TITLE
Add Selection API

### DIFF
--- a/src/DOM/HTML/Selection.js
+++ b/src/DOM/HTML/Selection.js
@@ -1,0 +1,154 @@
+"use strict";
+
+exports.anchorNode = function (selection) {
+  return function () {
+    return selection.anchorNode;
+  };
+};
+
+exports.anchorOffset = function (selection) {
+  return function () {
+    return selection.anchorOffset;
+  };
+};
+
+exports.focusNode = function (selection) {
+  return function () {
+    return selection.focusNode;
+  };
+};
+
+exports.focusOffset = function (selection) {
+  return function () {
+    return selection.focusOffset;
+  };
+};
+
+exports.isCollapsed = function (selection) {
+  return function () {
+    return selection.isCollapsed;
+  };
+};
+
+exports.rangeCount = function (selection) {
+  return function () {
+    return selection.rangeCount;
+  };
+};
+
+exports.typeImpl = function (selection) {
+  return function () {
+    return selection.type;
+  };
+};
+
+exports.getRangeAt = function (index) {
+  return function (selection) {
+    return function () {
+      return selection.getRangeAt(index);
+    };
+  };
+};
+
+exports.collapse = function (parentNode) {
+  return function (offset) {
+    return function (selection) {
+      return function () {
+        selection.collapse(parentNode, offset);
+      };
+    };
+  };
+};
+
+exports.extend = function (parentNode) {
+  return function (offset) {
+    return function (selection) {
+      return function () {
+        selection.extend(parentNode, offset);
+      };
+    };
+  };
+};
+
+exports.collapseToStart = function (selection) {
+  return function () {
+    selection.collapseToStart();
+  };
+};
+
+exports.collapseToEnd = function (selection) {
+  return function () {
+    selection.collapseToEnd();
+  };
+};
+
+exports.selectAllChildren = function (parentNode) {
+  return function (selection) {
+    return function () {
+      selection.selectAllChildren(parentNode);
+    };
+  };
+};
+
+exports.addRange = function (range) {
+  return function (selection) {
+    return function () {
+      selection.addRange(range);
+    };
+  };
+};
+
+exports.removeRange = function (range) {
+  return function (selection) {
+    return function () {
+      selection.removeRange(range);
+    };
+  };
+};
+
+exports.removeAllRanges = function (selection) {
+  return function () {
+    selection.removeAllRanges();
+  };
+};
+
+exports.deleteFromDocument = function (selection) {
+  return function () {
+    selection.deleteFromDocument();
+  };
+};
+
+exports.toString = function (selection) {
+  return function () {
+    return selection.toString();
+  };
+};
+
+exports.containsNode = function (aNode) {
+  return function (aPartlyContained) {
+    return function (selection) {
+      return function () {
+        return selection.containsNode(aNode, aPartlyContained);
+      };
+    };
+  };
+};
+
+exports.setBaseAndExtent = function (anchorNode) {
+  return function (anchorOffset) {
+    return function (focusNode) {
+      return function (focusOffset) {
+        return function (selection) {
+          return function () {
+            selection.setBaseAndExtent(
+              anchorNode,
+              anchorOffset,
+              focusNode,
+              focusOffset
+            );
+          };
+        };
+      };
+    };
+  };
+};

--- a/src/DOM/HTML/Selection.purs
+++ b/src/DOM/HTML/Selection.purs
@@ -1,0 +1,149 @@
+module DOM.HTML.Selection
+  ( SelectionType
+  , anchorNode
+  , anchorOffset
+  , focusNode
+  , focusOffset
+  , isCollapsed
+  , rangeCount
+  , type_
+  ) where
+
+import Prelude
+import Control.Monad.Eff (Eff)
+import DOM (DOM)
+import DOM.HTML.Types (Range, SELECTION, Selection)
+import DOM.Node.Types (Node)
+import Data.Maybe (Maybe(..), fromJust)
+
+foreign import anchorNode
+  :: forall eff
+   . Selection
+  -> Eff (selection :: SELECTION | eff) Node
+
+foreign import anchorOffset
+  :: forall eff
+   . Selection
+  -> Eff (selection :: SELECTION | eff) Int
+
+foreign import focusNode
+  :: forall eff
+   . Selection
+  -> Eff (selection :: SELECTION | eff) Node
+
+foreign import focusOffset
+  :: forall eff
+   . Selection
+  -> Eff (selection :: SELECTION | eff) Int
+
+foreign import isCollapsed
+  :: forall eff
+   . Selection
+  -> Eff (selection :: SELECTION | eff) Boolean
+
+foreign import rangeCount
+  :: forall eff
+   . Selection
+  -> Eff (selection :: SELECTION | eff) Int
+
+foreign import typeImpl
+  :: forall eff
+   . Selection
+  -> Eff (selection :: SELECTION | eff) String
+
+type_
+  :: forall eff
+   . Partial
+  => Selection
+  -> Eff (selection :: SELECTION | eff) SelectionType
+type_ = typeImpl >=> pure <<< fromJust <<< toSelectionType
+
+data SelectionType
+  = None
+  | Caret
+  | Range
+
+toSelectionType :: String -> Maybe SelectionType
+toSelectionType "None" = Just None
+toSelectionType "Caret" = Just Caret
+toSelectionType "Range" = Just Range
+toSelectionType _ = Nothing
+
+foreign import getRangeAt
+  :: forall eff
+   . Int
+  -> Selection
+  -> Eff (selection :: SELECTION | eff) Range
+
+foreign import collapse
+  :: forall eff
+   . Node
+  -> Int
+  -> Selection
+  -> Eff (selection :: SELECTION | eff) Unit
+
+foreign import extend
+  :: forall eff
+   . Node
+  -> Int
+  -> Selection
+  -> Eff (selection :: SELECTION | eff) Unit
+
+foreign import collapseToStart
+  :: forall eff
+   . Selection
+  -> Eff (selection :: SELECTION | eff) Unit
+
+foreign import collapseToEnd
+  :: forall eff
+   . Selection
+  -> Eff (selection :: SELECTION | eff) Unit
+
+foreign import selectAllChildren
+  :: forall eff
+   . Node
+  -> Selection
+  -> Eff (selection :: SELECTION | eff) Unit
+
+foreign import addRange
+  :: forall eff
+   . Range
+  -> Selection
+  -> Eff (selection :: SELECTION | eff) Unit
+
+foreign import removeRange
+  :: forall eff
+   . Range
+  -> Selection
+  -> Eff (selection :: SELECTION | eff) Unit
+
+foreign import removeAllRanges
+  :: forall eff
+   . Selection
+  -> Eff (selection :: SELECTION | eff) Unit
+
+foreign import deleteFromDocument
+  :: forall eff
+   . Selection
+  -> Eff (dom :: DOM, selection :: SELECTION | eff) Unit
+
+foreign import toString
+  :: forall eff
+   . Selection
+  -> Eff (selection :: SELECTION | eff) String
+
+foreign import containsNode
+  :: forall eff
+   . Node
+  -> Boolean
+  -> Selection
+  -> Eff (selection :: SELECTION | eff) Boolean
+
+foreign import setBaseAndExtent
+  :: forall eff
+   . Node
+  -> Int
+  -> Node
+  -> Int
+  -> Selection
+  -> Eff (selection :: SELECTION | eff) Unit

--- a/src/DOM/HTML/Selection.purs
+++ b/src/DOM/HTML/Selection.purs
@@ -15,6 +15,7 @@ import DOM (DOM)
 import DOM.HTML.Types (Range, SELECTION, Selection)
 import DOM.Node.Types (Node)
 import Data.Maybe (Maybe(..), fromJust)
+import Partial.Unsafe (unsafePartial)
 
 foreign import anchorNode
   :: forall eff
@@ -53,10 +54,9 @@ foreign import typeImpl
 
 type_
   :: forall eff
-   . Partial
-  => Selection
+   . Selection
   -> Eff (selection :: SELECTION | eff) SelectionType
-type_ = typeImpl >=> pure <<< fromJust <<< toSelectionType
+type_ = unsafePartial $ typeImpl >=> pure <<< fromJust <<< toSelectionType
 
 data SelectionType
   = None

--- a/src/DOM/HTML/Types.purs
+++ b/src/DOM/HTML/Types.purs
@@ -3,12 +3,15 @@ module DOM.HTML.Types
   ( Navigator
   , Location
   , History
+  , Range
+  , Selection
   , URL
   , Window
   , ALERT
   , CONFIRM
   , HISTORY
   , PROMPT
+  , SELECTION
   , WINDOW
   , windowToEventTarget
   , HTMLDocument
@@ -232,6 +235,10 @@ foreign import data Window :: *
 
 foreign import data History :: *
 
+foreign import data Range :: *
+
+foreign import data Selection :: *
+
 foreign import data URL :: *
 
 foreign import data ALERT :: !
@@ -241,6 +248,8 @@ foreign import data HISTORY :: !
 foreign import data PROMPT :: !
 
 foreign import data CONFIRM :: !
+
+foreign import data SELECTION :: !
 
 foreign import data WINDOW :: !
 

--- a/src/DOM/HTML/Window.js
+++ b/src/DOM/HTML/Window.js
@@ -192,4 +192,4 @@ exports.getSelection = function (window) {
   return function () {
     return window.getSelection();
   };
-}
+};

--- a/src/DOM/HTML/Window.js
+++ b/src/DOM/HTML/Window.js
@@ -187,3 +187,9 @@ exports.url = function (window) {
     return window.URL;
   };
 };
+
+exports.getSelection = function (window) {
+  return function () {
+    return window.getSelection();
+  };
+}

--- a/src/DOM/HTML/Window.purs
+++ b/src/DOM/HTML/Window.purs
@@ -27,7 +27,7 @@ module DOM.HTML.Window
 
 import Control.Monad.Eff (Eff)
 import DOM (DOM)
-import DOM.HTML.Types (ALERT, CONFIRM, HISTORY, HTMLDocument, History, Location, Navigator, PROMPT, WINDOW, Window, URL)
+import DOM.HTML.Types (ALERT, CONFIRM, HISTORY, HTMLDocument, History, Location, Navigator, PROMPT, SELECTION, Selection, URL, WINDOW, Window)
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 import Prelude (Unit, (<$>))
@@ -91,3 +91,5 @@ foreign import scrollBy :: forall eff. Int -> Int -> Window -> Eff (window :: WI
 foreign import scrollX :: forall eff. Window -> Eff (dom :: DOM | eff) Int
 
 foreign import scrollY :: forall eff. Window -> Eff (dom :: DOM | eff) Int
+
+foreign import getSelection :: forall eff. Window -> Eff (selection :: SELECTION | eff) Selection


### PR DESCRIPTION
This adds the `Selection` API as [documented on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Selection). Non-standard features such as [`modify`](https://developer.mozilla.org/en-US/docs/Web/API/Selection/modify) are not included.

Support for this API seems very good according to [Can I use](http://caniuse.com/#feat=selection-api).

I would appreciate as much feedback as possible on this, particularly on the introduction of the `SELECTION` effect, and around the effects used in general.

Some feedback on the approach used for `type` would also be great.

I think it also makes sense to add more on the `Range` data type. I'd like to do this in accordance with the [documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Range) but I'm not sure what the appropriate effect should be.

Thanks in advance.