### PR TITLE
export nodeType

### DIFF
--- a/src/DOM/Node/Node.purs
+++ b/src/DOM/Node/Node.purs
@@ -1,5 +1,6 @@
 module DOM.Node.Node
-  ( nodeTypeIndex
+  ( nodeType
+  , nodeTypeIndex
   , nodeName
   , baseURI
   , ownerDocument


### PR DESCRIPTION
It doesn't seem like this was excluded on purpose since it isn't used inside the module?

Needed for https://github.com/garyb/purescript-dom-classy/pull/5