### PR TITLE
Restore DOM effect to both usages of effect row for EventListener

### DIFF
--- a/src/DOM/Event/EventTarget.purs
+++ b/src/DOM/Event/EventTarget.purs
@@ -21,7 +21,7 @@ foreign import eventListener
 foreign import addEventListener
   :: forall eff
    . EventType
-  -> EventListener eff
+  -> EventListener (dom :: DOM | eff)
   -> Boolean
   -> EventTarget
   -> Eff (dom :: DOM | eff) Unit
@@ -31,7 +31,7 @@ foreign import addEventListener
 foreign import removeEventListener
   :: forall eff
    . EventType
-  -> EventListener eff
+  -> EventListener (dom :: DOM | eff)
   -> Boolean
   -> EventTarget
   -> Eff (dom :: DOM | eff) Unit


### PR DESCRIPTION
This seems to be causing problems: https://github.com/slamdata/purescript-halogen/pull/440#issuecomment-293538712

@nwolverson, @natefaubion - technically this is a breaking change, but since the current thing is breaking more stuff, do you think a patch release would be acceptable instead?