### PR TITLE
Add `toArray` for HTMLCollection

### DIFF
--- a/src/DOM/Node/HTMLCollection.js
+++ b/src/DOM/Node/HTMLCollection.js
@@ -6,6 +6,12 @@ exports.length = function (list) {
   };
 };
 
+exports.toArray = function (list) {
+  return function () {
+    return [].slice.call(list);
+  };
+};
+
 exports._item = function (index) {
   return function (list) {
     return function () {

--- a/src/DOM/Node/HTMLCollection.purs
+++ b/src/DOM/Node/HTMLCollection.purs
@@ -5,16 +5,17 @@ module DOM.Node.HTMLCollection
   ) where
 
 import Prelude
-import Control.Monad.Eff (Eff, forE)
-import Control.Monad.ST (ST)
-import Data.Array.ST (emptySTArray, pushSTArray, freeze)
-import Data.Maybe (Maybe(..))
+import Control.Monad.Eff (Eff)
+import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 import DOM (DOM)
 import DOM.Node.Types (Element, HTMLCollection, ElementId)
 
 -- | The number of elements in a HTMLCollection.
 foreign import length :: forall eff. HTMLCollection -> Eff (dom :: DOM | eff) Int
+
+-- | The elements of an HTMLCollection represented in an array.
+foreign import toArray :: forall eff. HTMLCollection -> Eff (dom :: DOM | eff) (Array Element)
 
 -- | The element in a HTMLCollection at the specified index, or Nothing if no such
 -- | element exists.
@@ -29,18 +30,3 @@ namedItem :: forall eff. ElementId -> HTMLCollection -> Eff (dom :: DOM | eff) (
 namedItem id = map toMaybe <<< _namedItem id
 
 foreign import _namedItem :: forall eff. ElementId -> HTMLCollection -> Eff (dom :: DOM | eff) (Nullable Element)
-
--- | The elements of an HTMLCollection represented in an array.
-toArray :: forall eff h. HTMLCollection -> Eff (dom :: DOM, st :: ST h | eff) (Array Element)
-toArray collection = do
-  result <- emptySTArray
-  len <- length collection
-
-  forE 0 len \i -> do
-    next <- item i collection
-
-    void $ case next of
-      Just elem -> pushSTArray result elem
-      Nothing   -> pure 0
-
-  freeze result

--- a/src/DOM/Node/HTMLCollection.purs
+++ b/src/DOM/Node/HTMLCollection.purs
@@ -5,8 +5,10 @@ module DOM.Node.HTMLCollection
   ) where
 
 import Prelude
-import Control.Monad.Eff (Eff)
-import Data.Maybe (Maybe)
+import Control.Monad.Eff (Eff, forE)
+import Control.Monad.ST (ST)
+import Data.Array.ST (emptySTArray, pushSTArray, freeze)
+import Data.Maybe (Maybe(..))
 import Data.Nullable (Nullable, toMaybe)
 import DOM (DOM)
 import DOM.Node.Types (Element, HTMLCollection, ElementId)
@@ -27,3 +29,18 @@ namedItem :: forall eff. ElementId -> HTMLCollection -> Eff (dom :: DOM | eff) (
 namedItem id = map toMaybe <<< _namedItem id
 
 foreign import _namedItem :: forall eff. ElementId -> HTMLCollection -> Eff (dom :: DOM | eff) (Nullable Element)
+
+-- | The elements of an HTMLCollection represented in an array.
+toArray :: forall eff h. HTMLCollection -> Eff (dom :: DOM, st :: ST h | eff) (Array Element)
+toArray collection = do
+  result <- emptySTArray
+  len <- length collection
+
+  forE 0 len \i -> do
+    next <- item i collection
+
+    void $ case next of
+      Just elem -> pushSTArray result elem
+      Nothing   -> pure 0
+
+  freeze result


### PR DESCRIPTION
With a lot of help from @garyb, here's the `toArray` for HTMLCollection.
It returns the elements within the collection as an Array of Element
objects. It was suggested that this be returned as an Unfoldable, but
the `item` function is effectful, so the plan was ruined.