### PR TITLE
Element matches and closest

### DIFF
--- a/src/DOM/Node/Element.js
+++ b/src/DOM/Node/Element.js
@@ -95,6 +95,40 @@ exports.removeAttribute = function (name) {
   };
 };
 
+// `matches` polyfill (https://caniuse.com/#feat=matchesselector)
+if (typeof Element.prototype.matches !== "function") {
+  Element.prototype.matches =
+    Element.prototype.msMatchesSelector
+      || Element.prototype.webkitMatchesSelector
+      || Element.prototype.oMatchesSelector
+      || Element.prototype.mozMatchesSelector;
+}
+
+exports.matches = function (selector) {
+  return function (element) {
+    return element.matches(selector);
+  }
+}
+
+// `closest` polyfill (https://caniuse.com/#feat=element-closest)
+if (typeof Element.prototype.closest !== "function") {
+  Element.prototype.closest = function closest(selector) {
+    return (function searchUpTree(selector, element) {
+      return element == null
+         ? null
+         : element.matches(selector)
+           ? element
+           : searchUpTree(selector, element.parentElement);
+    }(selector, this));
+  }
+}
+
+exports.closest = function (selector) {
+  return function (element) {
+    return element.closest(selector);
+  }
+}
+
 // - CSSOM ---------------------------------------------------------------------
 
 exports.scrollTop = function (node) {

--- a/src/DOM/Node/Element.purs
+++ b/src/DOM/Node/Element.purs
@@ -13,6 +13,8 @@ module DOM.Node.Element
   , setAttribute
   , getAttribute
   , removeAttribute
+  , matches
+  , closest
   , scrollTop
   , setScrollTop
   , scrollLeft
@@ -64,6 +66,9 @@ getAttribute attr = map toMaybe <<< _getAttribute attr
 
 foreign import _getAttribute :: forall eff. String -> Element -> Eff (dom :: DOM | eff) (Nullable String)
 foreign import removeAttribute :: forall eff. String -> Element -> Eff (dom :: DOM | eff) Unit
+
+foreign import matches :: forall eff. String -> Element -> Eff (dom :: DOM | eff) Boolean
+foreign import closest :: forall eff. String -> Element -> Eff (dom :: DOM | eff) (Nullable Element)
 
 foreign import scrollTop :: forall eff. Element -> Eff (dom :: DOM | eff) Number
 foreign import setScrollTop :: forall eff. Number -> Element -> Eff (dom :: DOM | eff) Unit


### PR DESCRIPTION
So these two require polyfills which doesn't fit the normal mold of what's in `Element.js`, but I think these are going to be useful functions for a lot of people... including myself for SlamData.

I made an example a while back: https://codepen.io/toastal/pen/dozqRj?editors=0010