### PR TITLE
dispatchEvent: use (exception :: EXCEPTION)

### DIFF
--- a/src/DOM/Event/EventTarget.purs
+++ b/src/DOM/Event/EventTarget.purs
@@ -41,4 +41,4 @@ foreign import dispatchEvent
   :: forall eff
    . Event
   -> EventTarget
-  -> Eff (dom :: DOM, err :: EXCEPTION | eff) Boolean
+  -> Eff (dom :: DOM, exception :: EXCEPTION | eff) Boolean


### PR DESCRIPTION
This way one can use `catchException` to remove the effect type.