### PR TITLE
Fix typo in WebSocket readyState

### DIFF
--- a/src/DOM/Websocket/WebSocket.js
+++ b/src/DOM/Websocket/WebSocket.js
@@ -16,7 +16,7 @@ exports.url = function (ws) {
 
 exports.readyStateImpl = function (ws) {
   return function () {
-    return ws.readyStateImpl;
+    return ws.readyState;
   };
 };
 


### PR DESCRIPTION
The JS-side property is called readyState, not readyStateImpl