### PR TITLE
Fix type of setHref, returns Unit not String

### DIFF
--- a/src/DOM/HTML/Location.purs
+++ b/src/DOM/HTML/Location.purs
@@ -38,7 +38,7 @@ foreign import hostname :: forall eff. Location -> Eff (dom :: DOM | eff) String
 foreign import setHostname :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
 
 foreign import href :: forall eff. Location -> Eff (dom :: DOM | eff) String
-foreign import setHref :: forall eff. String -> Location -> Eff (dom :: DOM | eff) String
+foreign import setHref :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
 
 foreign import origin :: forall eff. Location -> Eff (dom :: DOM | eff) String
 foreign import setOrigin :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit


### PR DESCRIPTION
https://github.com/houli/purescript-dom/blob/fix-setHref-type/src/DOM/HTML/Location.js#L60
`setHref` in the foreign module does not return anything. I saw on @paf31's TryPureScript stream he had to use void with this function here https://github.com/purescript/trypurescript/blob/gh-pages/src/Main.purs#L355