### PR TITLE
Added PopStateEvent

### DIFF
--- a/src/DOM/Event/PopstateEvent.purs
+++ b/src/DOM/Event/PopstateEvent.purs
@@ -1,0 +1,10 @@
+module DOM.Event.PopstateEvent
+  ( eventToPopStateEvent
+  ) where
+
+import DOM.Event.Types (Event, PopStateEvent, readPopStateEvent)
+import Data.Foreign (F, toForeign)
+import Prelude ((<<<))
+
+eventToPopStateEvent :: Event -> F PopStateEvent
+eventToPopStateEvent = readPopStateEvent <<< toForeign

--- a/src/DOM/Event/Types.purs
+++ b/src/DOM/Event/Types.purs
@@ -30,6 +30,9 @@ module DOM.Event.Types
   , CompositionEvent
   , compositionEventToEvent
   , readCompositionEvent
+  , PopStateEvent
+  , popStateEventToEvent
+  , readPopStateEvent
   , ProgressEvent
   , progressEventToEvent
   , readProgressEvent
@@ -140,6 +143,14 @@ compositionEventToEvent = U.unsafeCoerce
 
 readCompositionEvent :: Foreign -> F CompositionEvent
 readCompositionEvent = unsafeReadTagged "CompositionEvent"
+
+foreign import data PopStateEvent :: Type
+
+popStateEventToEvent :: PopStateEvent -> Event
+popStateEventToEvent = U.unsafeCoerce
+
+readPopStateEvent :: Foreign -> F PopStateEvent
+readPopStateEvent = unsafeReadTagged "PopStateEvent"
 
 foreign import data ProgressEvent :: Type
 


### PR DESCRIPTION
This adds `PopStateEvent` which is in [HTML5 spec](https://html.spec.whatwg.org/#the-popstateevent-interface).

There is no way of creating events, is this on purpose, or would you accept a PR which adds methods to create events?