### PR TITLE
HTMLIFrameElement.contentWindow

### DIFF
--- a/src/DOM/HTML/HTMLIFrameElement.js
+++ b/src/DOM/HTML/HTMLIFrameElement.js
@@ -85,3 +85,9 @@ exports._contentDocument = function (iframe) {
     return iframe.contentDocument;
   };
 };
+
+exports._contentWindow = function (iframe) {
+  return function () {
+    return iframe.contentWindow;
+  };
+};

--- a/src/DOM/HTML/HTMLIFrameElement.purs
+++ b/src/DOM/HTML/HTMLIFrameElement.purs
@@ -20,7 +20,7 @@ import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 
 import DOM (DOM)
-import DOM.HTML.Types (HTMLIFrameElement)
+import DOM.HTML.Types (Window, HTMLIFrameElement)
 import DOM.Node.Types (Document)
 
 foreign import src :: forall eff. HTMLIFrameElement -> Eff (dom :: DOM | eff) String
@@ -41,8 +41,10 @@ foreign import height :: forall eff. HTMLIFrameElement -> Eff (dom :: DOM | eff)
 foreign import setHeight :: forall eff. String -> HTMLIFrameElement -> Eff (dom :: DOM | eff) Unit
 
 foreign import _contentDocument :: forall eff. HTMLIFrameElement -> Eff (dom :: DOM | eff) (Nullable Document)
+foreign import _contentWindow :: forall eff. HTMLIFrameElement -> Eff (dom :: DOM | eff) (Nullable Window)
 
 contentDocument :: forall eff. HTMLIFrameElement -> Eff (dom :: DOM | eff) (Maybe Document)
 contentDocument = map toMaybe <<< _contentDocument
 
---   readonly attribute WindowProxy? contentWindow;
+contentWindow :: forall eff. HTMLIFrameElement -> Eff (dom :: DOM | eff) (Maybe Window)
+contentWindow = map toMaybe <<< _contentWindow

--- a/src/DOM/HTML/HTMLIFrameElement.purs
+++ b/src/DOM/HTML/HTMLIFrameElement.purs
@@ -10,6 +10,7 @@ module DOM.HTML.HTMLIFrameElement
   , height
   , setHeight
   , contentDocument
+  , contentWindow
   ) where
 
 import Prelude


### PR DESCRIPTION
So the return type here is Window which seems to be sufficient as `window`'s type is `WindowProxy` but `purescript-dom` refers to it as `Window`.

There may be a gap in my understanding here but it seems that as there is no interface to `WindowProxy` it doesn't need a type?