### PR TITLE
export `activeElement`

### DIFF
--- a/src/DOM/HTML/Document.purs
+++ b/src/DOM/HTML/Document.purs
@@ -1,6 +1,7 @@
 module DOM.HTML.Document
   ( body
   , readyState
+  , activeElement
   , module Exports
   ) where
 


### PR DESCRIPTION
I forgot to export the `activeElement` function ... which would solve my 

```
  57  import DOM.HTML.Document (activeElement)
                                ^^^^^^^^^^^^^
  
  Cannot import value activeElement from module DOM.HTML.Document
  It either does not exist or the module does not export it.
``` 

issue 😬 
