### PR TITLE
[WIP] Remove `Eff` in favor of `Effect`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "purescript-dom",
   "homepage": "https://github.com/purescript-web/purescript-dom",
-  "description": "PureScript type definitions and effect for interacting with the DOM",
+  "description": "PureScript type definitions for interacting with the DOM",
   "keywords": [
     "purescript"
   ],
@@ -30,7 +30,8 @@
     "purescript-media-types": "^3.0.0",
     "purescript-nullable": "^3.0.0",
     "purescript-prelude": "^3.0.0",
-    "purescript-unsafe-coerce": "^3.0.0"
+    "purescript-unsafe-coerce": "^3.0.0",
+    "purescript-effect": "^0.1.0"
   },
   "devDependencies": {
     "purescript-test-unit": "^11.0.0",

--- a/src/DOM.purs
+++ b/src/DOM.purs
@@ -1,7 +1,0 @@
-module DOM where
-
-import Control.Monad.Eff (kind Effect)
-
--- | Effect type for when the DOM is being manipulated or mutable values are
--- | being read from the DOM.
-foreign import data DOM :: Effect

--- a/src/DOM/Event/Event.purs
+++ b/src/DOM/Event/Event.purs
@@ -4,10 +4,9 @@ module DOM.Event.Event
   ) where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 import Data.Enum (toEnum)
 import Data.Maybe (fromJust)
-import DOM (DOM)
 import DOM.Event.EventPhase (EventPhase)
 import DOM.Event.Types (Event, EventType)
 import DOM.Event.Types (Event) as T
@@ -32,17 +31,11 @@ foreign import eventPhaseIndex :: Event -> Int
 
 -- | Prevents the event from bubbling up to futher event listeners. Other event
 -- | listeners on the current target will still fire.
-foreign import stopPropagation
-  :: forall eff
-   . Event
-  -> Eff (dom :: DOM | eff) Unit
+foreign import stopPropagation :: Event -> Effect Unit
 
 -- | Prevents all other listeners for the event from being called. This includes
 -- | event listeners added to the current target after the current listener.
-foreign import stopImmediatePropagation
-  :: forall eff
-   . Event
-  -> Eff (dom :: DOM | eff) Unit
+foreign import stopImmediatePropagation :: Event -> Effect Unit
 
 -- | Indicates whether the event will bubble up through the DOM or not.
 foreign import bubbles :: Event -> Boolean
@@ -51,10 +44,7 @@ foreign import bubbles :: Event -> Boolean
 foreign import cancelable :: Event -> Boolean
 
 -- | Cancels the event if it can be cancelled.
-foreign import preventDefault
-  :: forall eff
-   . Event
-  -> Eff (dom :: DOM | eff) Unit
+foreign import preventDefault :: Event -> Effect Unit
 
 -- | Indicates whether `preventDefault` was called on the event.
 foreign import defaultPrevented :: Event -> Boolean

--- a/src/DOM/Event/EventTarget.js
+++ b/src/DOM/Event/EventTarget.js
@@ -2,7 +2,7 @@
 
 exports.eventListener = function (fn) {
   return function (event) {
-    return fn(event)();
+    return fn(event);
   };
 };
 

--- a/src/DOM/Event/EventTarget.purs
+++ b/src/DOM/Event/EventTarget.purs
@@ -12,7 +12,7 @@ foreign import data EventListener :: Type
 foreign import eventListener
   :: forall a
    . (Event -> Effect a)
-  -> EventListener
+  -> Effect EventListener
 
 -- | Adds a listener to an event target. The boolean argument indicates whether
 -- | the listener should be added for the "capture" phase.

--- a/src/DOM/Event/EventTarget.purs
+++ b/src/DOM/Event/EventTarget.purs
@@ -1,44 +1,39 @@
 module DOM.Event.EventTarget where
 
 import Prelude
-import Control.Monad.Eff (kind Effect, Eff)
-import Control.Monad.Eff.Exception (EXCEPTION)
-import DOM (DOM)
+import Control.Monad.Effect (Effect)
 import DOM.Event.Types (EventTarget, Event, EventType)
 
 -- | A boxed function that can be used as an event listener. This is necessary
--- | due to the underlying implementation of Eff functions.
-foreign import data EventListener :: # Effect -> Type
+-- | due to the underlying implementation of Effect functions.
+foreign import data EventListener :: Type
 
--- | Creates an EventListener from a normal PureScript Eff function.
+-- | Creates an EventListener from a normal PureScript Effect function.
 foreign import eventListener
-  :: forall eff a
-   . (Event -> Eff eff a)
-  -> EventListener eff
+  :: forall a
+   . (Event -> Effect a)
+  -> EventListener
 
 -- | Adds a listener to an event target. The boolean argument indicates whether
 -- | the listener should be added for the "capture" phase.
 foreign import addEventListener
-  :: forall eff
-   . EventType
-  -> EventListener (dom :: DOM | eff)
+  :: EventType
+  -> EventListener
   -> Boolean
   -> EventTarget
-  -> Eff (dom :: DOM | eff) Unit
+  -> Effect Unit
 
 -- | Removes a listener to an event target. The boolean argument indicates
 -- | whether the listener should be removed for the "capture" phase.
 foreign import removeEventListener
-  :: forall eff
-   . EventType
-  -> EventListener (dom :: DOM | eff)
+  :: EventType
+  -> EventListener
   -> Boolean
   -> EventTarget
-  -> Eff (dom :: DOM | eff) Unit
+  -> Effect Unit
 
 -- | Dispatches an event from an event target.
 foreign import dispatchEvent
-  :: forall eff
-   . Event
+  :: Event
   -> EventTarget
-  -> Eff (dom :: DOM, err :: EXCEPTION | eff) Boolean
+  -> Effect Boolean

--- a/src/DOM/Event/KeyboardEvent.purs
+++ b/src/DOM/Event/KeyboardEvent.purs
@@ -32,11 +32,10 @@ module DOM.Event.KeyboardEvent
   ) where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 import Data.Enum (class BoundedEnum, class Enum, Cardinality(..), defaultPred, defaultSucc, toEnum)
 import Data.Foreign (F, toForeign)
 import Data.Maybe (Maybe(..), fromJust)
-import DOM (DOM)
 import DOM.Event.Types (Event, KeyboardEvent, readKeyboardEvent)
 import DOM.Event.Types (KeyboardEvent, keyboardEventToEvent, readKeyboardEvent) as T
 
@@ -108,7 +107,6 @@ foreign import repeat :: KeyboardEvent -> Boolean
 foreign import isComposing :: KeyboardEvent -> Boolean
 
 foreign import getModifierState
-  :: forall eff
-   . String
+  :: String
   -> KeyboardEvent
-  -> Eff (dom :: DOM | eff) Boolean
+  -> Effect Boolean

--- a/src/DOM/Event/MouseEvent.purs
+++ b/src/DOM/Event/MouseEvent.purs
@@ -18,11 +18,10 @@ module DOM.Event.MouseEvent
   ) where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 import Data.Foreign (F, toForeign)
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
-import DOM (DOM)
 import DOM.Event.Types (Event, EventTarget, MouseEvent, readMouseEvent)
 import DOM.Event.Types (MouseEvent, mouseEventToEvent, readMouseEvent) as T
 
@@ -59,7 +58,6 @@ relatedTarget = toMaybe <$> _relatedTarget
 foreign import buttons :: MouseEvent -> Int
 
 foreign import getModifierState
-  :: forall eff
-   . String
+  :: String
   -> MouseEvent
-  -> Eff (dom :: DOM | eff) Boolean
+  -> Effect Boolean

--- a/src/DOM/File/FileReader.purs
+++ b/src/DOM/File/FileReader.purs
@@ -9,31 +9,30 @@ module DOM.File.FileReader
   ) where
 
 import Prelude
-import Control.Monad.Eff (Eff)
-import DOM (DOM)
+import Control.Monad.Effect (Effect)
 import DOM.File.FileReader.ReadyState (toEnumReadyState, ReadyState)
 import DOM.File.Types (Blob, FileReader)
 import Data.Foreign (Foreign)
 import Data.Maybe (fromJust)
 import Partial.Unsafe (unsafePartial)
 
-foreign import fileReader :: forall eff. Eff (dom :: DOM | eff) FileReader
+foreign import fileReader :: Effect FileReader
 
-foreign import error :: forall eff. FileReader -> Eff (dom :: DOM | eff) Foreign
+foreign import error :: FileReader -> Effect Foreign
 
-foreign import readyStateImpl :: forall eff. FileReader -> Eff (dom :: DOM | eff) Int
+foreign import readyStateImpl :: FileReader -> Effect Int
 
-readyState :: forall eff. FileReader -> Eff (dom :: DOM | eff) ReadyState
+readyState :: FileReader -> Effect ReadyState
 readyState fr = do
   rs <- readyStateImpl fr
   pure $ unsafePartial $ fromJust $ toEnumReadyState rs
 
-foreign import result :: forall eff. FileReader -> Eff (dom :: DOM | eff) Foreign
+foreign import result :: FileReader -> Effect Foreign
 
-foreign import abort :: FileReader -> forall eff. Eff (dom :: DOM | eff) Unit
+foreign import abort :: FileReader -> Effect Unit
 
-foreign import readAsText :: Blob -> FileReader -> forall eff. Eff (dom :: DOM | eff) Unit
+foreign import readAsText :: Blob -> FileReader -> Effect Unit
 
-foreign import readAsArrayBuffer :: Blob -> FileReader -> forall eff. Eff (dom :: DOM | eff) Unit
+foreign import readAsArrayBuffer :: Blob -> FileReader -> Effect Unit
 
-foreign import readAsDataURL :: Blob -> FileReader -> forall eff. Eff (dom :: DOM | eff) Unit
+foreign import readAsDataURL :: Blob -> FileReader -> Effect Unit

--- a/src/DOM/HTML.purs
+++ b/src/DOM/HTML.purs
@@ -1,7 +1,6 @@
 module DOM.HTML where
 
-import Control.Monad.Eff (Eff)
-import DOM (DOM)
+import Control.Monad.Effect (Effect)
 import DOM.HTML.Types (Window)
 
-foreign import window :: forall eff. Eff (dom :: DOM | eff) Window
+foreign import window :: Effect Window

--- a/src/DOM/HTML/Document.purs
+++ b/src/DOM/HTML/Document.purs
@@ -7,8 +7,7 @@ module DOM.HTML.Document
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
-import DOM (DOM)
+import Control.Monad.Effect (Effect)
 import DOM.HTML.Document.ReadyState (ReadyState(..)) as Exports
 import DOM.HTML.Document.ReadyState (ReadyState, parseReadyState)
 import DOM.HTML.Types (HTMLElement, HTMLDocument)
@@ -16,17 +15,17 @@ import Data.Maybe (Maybe, fromJust)
 import Data.Nullable (Nullable, toMaybe)
 import Partial.Unsafe (unsafePartial)
 
-foreign import _body :: forall eff. HTMLDocument -> Eff (dom :: DOM | eff) (Nullable HTMLElement)
+foreign import _body :: HTMLDocument -> Effect (Nullable HTMLElement)
 
-body :: forall eff. HTMLDocument -> Eff (dom :: DOM | eff) (Maybe HTMLElement)
+body :: HTMLDocument -> Effect (Maybe HTMLElement)
 body = map toMaybe <<< _body
 
-foreign import _readyState :: forall eff. HTMLDocument -> Eff (dom :: DOM | eff) String
+foreign import _readyState :: HTMLDocument -> Effect String
 
-readyState :: forall eff. HTMLDocument -> Eff (dom :: DOM | eff) ReadyState
+readyState :: HTMLDocument -> Effect ReadyState
 readyState = map (unsafePartial fromJust <<< parseReadyState) <<< _readyState
 
-foreign import _activeElement :: forall eff. HTMLDocument -> Eff (dom :: DOM | eff) (Nullable HTMLElement)
+foreign import _activeElement :: HTMLDocument -> Effect (Nullable HTMLElement)
 
-activeElement :: forall eff. HTMLDocument -> Eff (dom :: DOM | eff) (Maybe HTMLElement)
+activeElement :: HTMLDocument -> Effect (Maybe HTMLElement)
 activeElement = map toMaybe <<< _activeElement

--- a/src/DOM/HTML/Event/DataTransfer.purs
+++ b/src/DOM/HTML/Event/DataTransfer.purs
@@ -11,8 +11,7 @@ module DOM.HTML.Event.DataTransfer
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
-import DOM (DOM)
+import Control.Monad.Effect (Effect)
 import DOM.File.Types (FileList)
 import Data.Maybe (Maybe)
 import Data.MediaType (MediaType(..))
@@ -37,23 +36,21 @@ foreign import _files :: DataTransfer -> Nullable FileList
 foreign import types :: DataTransfer -> Array String
 
 foreign import getDataImpl
-  :: forall eff
-   . String
+  :: String
   -> DataTransfer
-  -> Eff (dom :: DOM | eff) String
+  -> Effect String
 
 -- | Retrieves the data for a given media type, or an empty string if data for
 -- | that type does not exist or the data transfer object contains no data.
 getData
-  :: forall eff. MediaType -> DataTransfer -> Eff (dom :: DOM | eff) String
+  :: MediaType -> DataTransfer -> Effect String
 getData (MediaType format) dt = getDataImpl format dt
 
 foreign import setDataImpl
-  :: forall eff
-   . String
+  :: String
   -> String
   -> DataTransfer
-  -> Eff (dom :: DOM | eff) Unit
+  -> Effect Unit
 
 -- | Sets the data transfer object's data for a given media format.
 -- |
@@ -61,14 +58,13 @@ foreign import setDataImpl
 -- |
 -- |     setData textPlain "Foo" dataTransfer
 setData
-  :: forall eff
-   . MediaType
+  :: MediaType
   -> String
   -> DataTransfer
-  -> Eff (dom :: DOM | eff) Unit
+  -> Effect Unit
 setData (MediaType format) dat dt = setDataImpl format dat dt
 
-foreign import dropEffectImpl :: forall eff. DataTransfer -> Eff (dom :: DOM | eff) String
+foreign import dropEffectImpl :: DataTransfer -> Effect String
 
 data DropEffect = Copy | Link | Move | None
 
@@ -76,7 +72,7 @@ derive instance eqDropEffect :: Eq DropEffect
 derive instance ordDropEffect :: Ord DropEffect
 
 --| Gets the data transfer object's drop effect.
-dropEffect :: forall eff. DataTransfer -> Eff (dom :: DOM | eff) DropEffect
+dropEffect :: DataTransfer -> Effect DropEffect
 dropEffect dt = do
   de <- dropEffectImpl dt
   pure $ unsafePartial $ case de of
@@ -86,10 +82,10 @@ dropEffect dt = do
     "none" -> None
     _ -> crashWith "Impossible according to https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/dropEffect"
 
-foreign import setDropEffectImpl :: forall eff. String -> DataTransfer -> Eff (dom :: DOM | eff) Unit
+foreign import setDropEffectImpl :: String -> DataTransfer -> Effect Unit
 
 --| Sets the data transfer object's drop effect.
-setDropEffect :: forall eff. DropEffect -> DataTransfer -> Eff (dom :: DOM | eff) Unit
+setDropEffect :: DropEffect -> DataTransfer -> Effect Unit
 setDropEffect de = setDropEffectImpl case de of
   Copy -> "copy"
   Link -> "link"

--- a/src/DOM/HTML/HTMLAnchorElement.purs
+++ b/src/DOM/HTML/HTMLAnchorElement.purs
@@ -2,31 +2,30 @@ module DOM.HTML.HTMLAnchorElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLAnchorElement)
 import DOM.Node.Types (DOMTokenList)
 
-foreign import target :: forall eff. HTMLAnchorElement -> Eff (dom :: DOM | eff) String
-foreign import setTarget :: forall eff. String -> HTMLAnchorElement -> Eff (dom :: DOM | eff) Unit
+foreign import target :: HTMLAnchorElement -> Effect String
+foreign import setTarget :: String -> HTMLAnchorElement -> Effect Unit
 
-foreign import download :: forall eff. HTMLAnchorElement -> Eff (dom :: DOM | eff) String
-foreign import setDownload :: forall eff. String -> HTMLAnchorElement -> Eff (dom :: DOM | eff) Unit
+foreign import download :: HTMLAnchorElement -> Effect String
+foreign import setDownload :: String -> HTMLAnchorElement -> Effect Unit
 
-foreign import rel :: forall eff. HTMLAnchorElement -> Eff (dom :: DOM | eff) String
-foreign import setRel :: forall eff. String -> HTMLAnchorElement -> Eff (dom :: DOM | eff) Unit
+foreign import rel :: HTMLAnchorElement -> Effect String
+foreign import setRel :: String -> HTMLAnchorElement -> Effect Unit
 
-foreign import rev :: forall eff. HTMLAnchorElement -> Eff (dom :: DOM | eff) String
-foreign import setRev :: forall eff. String -> HTMLAnchorElement -> Eff (dom :: DOM | eff) Unit
+foreign import rev :: HTMLAnchorElement -> Effect String
+foreign import setRev :: String -> HTMLAnchorElement -> Effect Unit
 
-foreign import relList :: forall eff. HTMLAnchorElement -> Eff (dom :: DOM | eff) DOMTokenList
+foreign import relList :: HTMLAnchorElement -> Effect DOMTokenList
 
-foreign import hreflang :: forall eff. HTMLAnchorElement -> Eff (dom :: DOM | eff) String
-foreign import setHreflang :: forall eff. String -> HTMLAnchorElement -> Eff (dom :: DOM | eff) Unit
+foreign import hreflang :: HTMLAnchorElement -> Effect String
+foreign import setHreflang :: String -> HTMLAnchorElement -> Effect Unit
 
-foreign import type_ :: forall eff. HTMLAnchorElement -> Eff (dom :: DOM | eff) String
-foreign import setType :: forall eff. String -> HTMLAnchorElement -> Eff (dom :: DOM | eff) Unit
+foreign import type_ :: HTMLAnchorElement -> Effect String
+foreign import setType :: String -> HTMLAnchorElement -> Effect Unit
 
-foreign import text :: forall eff. HTMLAnchorElement -> Eff (dom :: DOM | eff) String
-foreign import setText :: forall eff. String -> HTMLAnchorElement -> Eff (dom :: DOM | eff) Unit
+foreign import text :: HTMLAnchorElement -> Effect String
+foreign import setText :: String -> HTMLAnchorElement -> Effect Unit

--- a/src/DOM/HTML/HTMLAreaElement.purs
+++ b/src/DOM/HTML/HTMLAreaElement.purs
@@ -2,34 +2,33 @@ module DOM.HTML.HTMLAreaElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLAreaElement)
 import DOM.Node.Types (DOMTokenList)
 
-foreign import alt :: forall eff. HTMLAreaElement -> Eff (dom :: DOM | eff) String
-foreign import setAlt :: forall eff. String -> HTMLAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import alt :: HTMLAreaElement -> Effect String
+foreign import setAlt :: String -> HTMLAreaElement -> Effect Unit
 
-foreign import coords :: forall eff. HTMLAreaElement -> Eff (dom :: DOM | eff) String
-foreign import setCoords :: forall eff. String -> HTMLAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import coords :: HTMLAreaElement -> Effect String
+foreign import setCoords :: String -> HTMLAreaElement -> Effect Unit
 
-foreign import shape :: forall eff. HTMLAreaElement -> Eff (dom :: DOM | eff) String
-foreign import setShape :: forall eff. String -> HTMLAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import shape :: HTMLAreaElement -> Effect String
+foreign import setShape :: String -> HTMLAreaElement -> Effect Unit
 
-foreign import target :: forall eff. HTMLAreaElement -> Eff (dom :: DOM | eff) String
-foreign import setTarget :: forall eff. String -> HTMLAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import target :: HTMLAreaElement -> Effect String
+foreign import setTarget :: String -> HTMLAreaElement -> Effect Unit
 
-foreign import download :: forall eff. HTMLAreaElement -> Eff (dom :: DOM | eff) String
-foreign import setDownload :: forall eff. String -> HTMLAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import download :: HTMLAreaElement -> Effect String
+foreign import setDownload :: String -> HTMLAreaElement -> Effect Unit
 
-foreign import rel :: forall eff. HTMLAreaElement -> Eff (dom :: DOM | eff) String
-foreign import setRel :: forall eff. String -> HTMLAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import rel :: HTMLAreaElement -> Effect String
+foreign import setRel :: String -> HTMLAreaElement -> Effect Unit
 
-foreign import relList :: forall eff. HTMLAreaElement -> Eff (dom :: DOM | eff) DOMTokenList
+foreign import relList :: HTMLAreaElement -> Effect DOMTokenList
 
-foreign import hreflang :: forall eff. HTMLAreaElement -> Eff (dom :: DOM | eff) String
-foreign import setHreflang :: forall eff. String -> HTMLAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import hreflang :: HTMLAreaElement -> Effect String
+foreign import setHreflang :: String -> HTMLAreaElement -> Effect Unit
 
-foreign import type_ :: forall eff. HTMLAreaElement -> Eff (dom :: DOM | eff) String
-foreign import setType :: forall eff. String -> HTMLAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import type_ :: HTMLAreaElement -> Effect String
+foreign import setType :: String -> HTMLAreaElement -> Effect Unit

--- a/src/DOM/HTML/HTMLBaseElement.purs
+++ b/src/DOM/HTML/HTMLBaseElement.purs
@@ -2,13 +2,12 @@ module DOM.HTML.HTMLBaseElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLBaseElement)
 
-foreign import href :: forall eff. HTMLBaseElement -> Eff (dom :: DOM | eff) String
-foreign import setHref :: forall eff. String -> HTMLBaseElement -> Eff (dom :: DOM | eff) Unit
+foreign import href :: HTMLBaseElement -> Effect String
+foreign import setHref :: String -> HTMLBaseElement -> Effect Unit
 
-foreign import target :: forall eff. HTMLBaseElement -> Eff (dom :: DOM | eff) String
-foreign import setTarget :: forall eff. String -> HTMLBaseElement -> Eff (dom :: DOM | eff) Unit
+foreign import target :: HTMLBaseElement -> Effect String
+foreign import setTarget :: String -> HTMLBaseElement -> Effect Unit

--- a/src/DOM/HTML/HTMLButtonElement.purs
+++ b/src/DOM/HTML/HTMLButtonElement.purs
@@ -30,58 +30,57 @@ module DOM.HTML.HTMLButtonElement
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 
-import DOM (DOM)
 import DOM.Node.Types (NodeList)
 import DOM.HTML.Types (HTMLButtonElement, HTMLFormElement, ValidityState)
 
-foreign import autofocus :: forall eff. HTMLButtonElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setAutofocus :: forall eff. Boolean -> HTMLButtonElement -> Eff (dom :: DOM | eff) Unit
+foreign import autofocus :: HTMLButtonElement -> Effect Boolean
+foreign import setAutofocus :: Boolean -> HTMLButtonElement -> Effect Unit
 
-foreign import disabled :: forall eff. HTMLButtonElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setDisabled :: forall eff. Boolean -> HTMLButtonElement -> Eff (dom :: DOM | eff) Unit
+foreign import disabled :: HTMLButtonElement -> Effect Boolean
+foreign import setDisabled :: Boolean -> HTMLButtonElement -> Effect Unit
 
-form :: forall eff. HTMLButtonElement -> Eff (dom :: DOM | eff) (Maybe HTMLFormElement)
+form :: HTMLButtonElement -> Effect (Maybe HTMLFormElement)
 form = map toMaybe <<< _form
 
-foreign import _form :: forall eff. HTMLButtonElement -> Eff (dom :: DOM | eff) (Nullable HTMLFormElement)
+foreign import _form :: HTMLButtonElement -> Effect (Nullable HTMLFormElement)
 
-foreign import formAction :: forall eff. HTMLButtonElement -> Eff (dom :: DOM | eff) String
-foreign import setFormAction :: forall eff. String -> HTMLButtonElement -> Eff (dom :: DOM | eff) Unit
+foreign import formAction :: HTMLButtonElement -> Effect String
+foreign import setFormAction :: String -> HTMLButtonElement -> Effect Unit
 
-foreign import formEnctype :: forall eff. HTMLButtonElement -> Eff (dom :: DOM | eff) String
-foreign import setFormEnctype :: forall eff. String -> HTMLButtonElement -> Eff (dom :: DOM | eff) Unit
+foreign import formEnctype :: HTMLButtonElement -> Effect String
+foreign import setFormEnctype :: String -> HTMLButtonElement -> Effect Unit
 
-foreign import formMethod :: forall eff. HTMLButtonElement -> Eff (dom :: DOM | eff) String
-foreign import setFormMethod :: forall eff. String -> HTMLButtonElement -> Eff (dom :: DOM | eff) Unit
+foreign import formMethod :: HTMLButtonElement -> Effect String
+foreign import setFormMethod :: String -> HTMLButtonElement -> Effect Unit
 
-foreign import formNoValidate :: forall eff. HTMLButtonElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setFormNoValidate :: forall eff. Boolean -> HTMLButtonElement -> Eff (dom :: DOM | eff) Unit
+foreign import formNoValidate :: HTMLButtonElement -> Effect Boolean
+foreign import setFormNoValidate :: Boolean -> HTMLButtonElement -> Effect Unit
 
-foreign import formTarget :: forall eff. HTMLButtonElement -> Eff (dom :: DOM | eff) String
-foreign import setFormTarget :: forall eff. String -> HTMLButtonElement -> Eff (dom :: DOM | eff) Unit
+foreign import formTarget :: HTMLButtonElement -> Effect String
+foreign import setFormTarget :: String -> HTMLButtonElement -> Effect Unit
 
-foreign import name :: forall eff. HTMLButtonElement -> Eff (dom :: DOM | eff) String
-foreign import setName :: forall eff. String -> HTMLButtonElement -> Eff (dom :: DOM | eff) Unit
+foreign import name :: HTMLButtonElement -> Effect String
+foreign import setName :: String -> HTMLButtonElement -> Effect Unit
 
-foreign import type_ :: forall eff. HTMLButtonElement -> Eff (dom :: DOM | eff) String
-foreign import setType :: forall eff. String -> HTMLButtonElement -> Eff (dom :: DOM | eff) Unit
+foreign import type_ :: HTMLButtonElement -> Effect String
+foreign import setType :: String -> HTMLButtonElement -> Effect Unit
 
-foreign import value :: forall eff. HTMLButtonElement -> Eff (dom :: DOM | eff) String
-foreign import setValue :: forall eff. String -> HTMLButtonElement -> Eff (dom :: DOM | eff) Unit
+foreign import value :: HTMLButtonElement -> Effect String
+foreign import setValue :: String -> HTMLButtonElement -> Effect Unit
 
-foreign import willValidate :: forall eff. HTMLButtonElement -> Eff (dom :: DOM | eff) Boolean
+foreign import willValidate :: HTMLButtonElement -> Effect Boolean
 
-foreign import validity :: forall eff. HTMLButtonElement -> Eff (dom :: DOM | eff) ValidityState
+foreign import validity :: HTMLButtonElement -> Effect ValidityState
 
-foreign import validationMessage :: forall eff. HTMLButtonElement -> Eff (dom :: DOM | eff) String
+foreign import validationMessage :: HTMLButtonElement -> Effect String
 
-foreign import checkValidity :: forall eff. HTMLButtonElement -> Eff (dom :: DOM | eff) Boolean
+foreign import checkValidity :: HTMLButtonElement -> Effect Boolean
 
-foreign import setCustomValidity :: forall eff. String -> HTMLButtonElement -> Eff (dom :: DOM | eff) Unit
+foreign import setCustomValidity :: String -> HTMLButtonElement -> Effect Unit
 
-foreign import labels :: forall eff. HTMLButtonElement -> Eff (dom :: DOM | eff) NodeList
+foreign import labels :: HTMLButtonElement -> Effect NodeList

--- a/src/DOM/HTML/HTMLCanvasElement.purs
+++ b/src/DOM/HTML/HTMLCanvasElement.purs
@@ -2,18 +2,17 @@ module DOM.HTML.HTMLCanvasElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLCanvasElement)
 
 -- typedef (CanvasRenderingContext2D or WebGLRenderingContext) RenderingContext;
 
-foreign import width :: forall eff. HTMLCanvasElement -> Eff (dom :: DOM | eff) Int
-foreign import setWidth :: forall eff. Int -> HTMLCanvasElement -> Eff (dom :: DOM | eff) Unit
+foreign import width :: HTMLCanvasElement -> Effect Int
+foreign import setWidth :: Int -> HTMLCanvasElement -> Effect Unit
 
-foreign import height :: forall eff. HTMLCanvasElement -> Eff (dom :: DOM | eff) Int
-foreign import setHeight :: forall eff. Int -> HTMLCanvasElement -> Eff (dom :: DOM | eff) Unit
+foreign import height :: HTMLCanvasElement -> Effect Int
+foreign import setHeight :: Int -> HTMLCanvasElement -> Effect Unit
 
 --   RenderingContext? getContext(DOMString contextId, any... arguments);
 

--- a/src/DOM/HTML/HTMLDataElement.purs
+++ b/src/DOM/HTML/HTMLDataElement.purs
@@ -2,10 +2,9 @@ module DOM.HTML.HTMLDataElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLDataElement)
 
-foreign import value :: forall eff. HTMLDataElement -> Eff (dom :: DOM | eff) String
-foreign import setValue :: forall eff. String -> HTMLDataElement -> Eff (dom :: DOM | eff) Unit
+foreign import value :: HTMLDataElement -> Effect String
+foreign import setValue :: String -> HTMLDataElement -> Effect Unit

--- a/src/DOM/HTML/HTMLDataListElement.purs
+++ b/src/DOM/HTML/HTMLDataListElement.purs
@@ -1,9 +1,8 @@
 module DOM.HTML.HTMLDataListElement where
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLDataListElement)
 import DOM.Node.Types (HTMLCollection)
 
-foreign import options :: forall eff. HTMLDataListElement -> Eff (dom :: DOM | eff) HTMLCollection
+foreign import options :: HTMLDataListElement -> Effect HTMLCollection

--- a/src/DOM/HTML/HTMLElement.purs
+++ b/src/DOM/HTML/HTMLElement.purs
@@ -33,46 +33,45 @@ module DOM.HTML.HTMLElement
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
-import DOM (DOM)
+import Control.Monad.Effect (Effect)
 import DOM.HTML.Types (HTMLElement)
 import DOM.Node.Types (DOMTokenList, Element)
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 
-foreign import title :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) String
-foreign import setTitle :: forall eff. String -> HTMLElement -> Eff (dom :: DOM | eff) Unit
+foreign import title :: HTMLElement -> Effect String
+foreign import setTitle :: String -> HTMLElement -> Effect Unit
 
-foreign import lang :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) String
-foreign import setLang :: forall eff. String -> HTMLElement -> Eff (dom :: DOM | eff) Unit
+foreign import lang :: HTMLElement -> Effect String
+foreign import setLang :: String -> HTMLElement -> Effect Unit
 
-foreign import dir :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) String
-foreign import setDir :: forall eff. String -> HTMLElement -> Eff (dom :: DOM | eff) Unit
+foreign import dir :: HTMLElement -> Effect String
+foreign import setDir :: String -> HTMLElement -> Effect Unit
 
-foreign import className :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) String
-foreign import setClassName :: forall eff. String -> HTMLElement -> Eff (dom :: DOM | eff) Unit
+foreign import className :: HTMLElement -> Effect String
+foreign import setClassName :: String -> HTMLElement -> Effect Unit
 
-foreign import classList :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) DOMTokenList
+foreign import classList :: HTMLElement -> Effect DOMTokenList
 
-foreign import hidden :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setHidden :: forall eff. Boolean -> HTMLElement -> Eff (dom :: DOM | eff) Unit
+foreign import hidden :: HTMLElement -> Effect Boolean
+foreign import setHidden :: Boolean -> HTMLElement -> Effect Unit
 
-foreign import tabIndex :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Int
-foreign import setTabIndex :: forall eff. Int -> HTMLElement -> Eff (dom :: DOM | eff) Unit
+foreign import tabIndex :: HTMLElement -> Effect Int
+foreign import setTabIndex :: Int -> HTMLElement -> Effect Unit
 
-foreign import draggable :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setDraggable :: forall eff. Boolean -> HTMLElement -> Eff (dom :: DOM | eff) Unit
+foreign import draggable :: HTMLElement -> Effect Boolean
+foreign import setDraggable :: Boolean -> HTMLElement -> Effect Unit
 
-foreign import contentEditable :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) String
-foreign import setContentEditable :: forall eff. String -> HTMLElement -> Eff (dom :: DOM | eff) Unit
-foreign import isContentEditable :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Boolean
+foreign import contentEditable :: HTMLElement -> Effect String
+foreign import setContentEditable :: String -> HTMLElement -> Effect Unit
+foreign import isContentEditable :: HTMLElement -> Effect Boolean
 
-foreign import spellcheck :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setSpellcheck :: forall eff. Boolean -> HTMLElement -> Eff (dom :: DOM | eff) Unit
+foreign import spellcheck :: HTMLElement -> Effect Boolean
+foreign import setSpellcheck :: Boolean -> HTMLElement -> Effect Unit
 
-foreign import click :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Unit
-foreign import focus :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Unit
-foreign import blur :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Unit
+foreign import click :: HTMLElement -> Effect Unit
+foreign import focus :: HTMLElement -> Effect Unit
+foreign import blur :: HTMLElement -> Effect Unit
 
 type DOMRect =
   { top :: Number
@@ -83,14 +82,14 @@ type DOMRect =
   , height :: Number
   }
 
-foreign import getBoundingClientRect :: forall eff . HTMLElement -> Eff (dom :: DOM | eff) DOMRect
+foreign import getBoundingClientRect :: HTMLElement -> Effect DOMRect
 
-foreign import _offsetParent :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) (Nullable Element)
+foreign import _offsetParent :: HTMLElement -> Effect (Nullable Element)
 
-offsetParent :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) (Maybe Element)
+offsetParent :: HTMLElement -> Effect (Maybe Element)
 offsetParent = map toMaybe <<< _offsetParent
 
-foreign import offsetTop :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Number
-foreign import offsetLeft :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Number
-foreign import offsetWidth :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Number
-foreign import offsetHeight :: forall eff. HTMLElement -> Eff (dom :: DOM | eff) Number
+foreign import offsetTop :: HTMLElement -> Effect Number
+foreign import offsetLeft :: HTMLElement -> Effect Number
+foreign import offsetWidth :: HTMLElement -> Effect Number
+foreign import offsetHeight :: HTMLElement -> Effect Number

--- a/src/DOM/HTML/HTMLEmbedElement.purs
+++ b/src/DOM/HTML/HTMLEmbedElement.purs
@@ -2,19 +2,18 @@ module DOM.HTML.HTMLEmbedElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLEmbedElement)
 
-foreign import src :: forall eff. HTMLEmbedElement -> Eff (dom :: DOM | eff) String
-foreign import setSrc :: forall eff. String -> HTMLEmbedElement -> Eff (dom :: DOM | eff) Unit
+foreign import src :: HTMLEmbedElement -> Effect String
+foreign import setSrc :: String -> HTMLEmbedElement -> Effect Unit
 
-foreign import type_ :: forall eff. HTMLEmbedElement -> Eff (dom :: DOM | eff) String
-foreign import setType :: forall eff. String -> HTMLEmbedElement -> Eff (dom :: DOM | eff) Unit
+foreign import type_ :: HTMLEmbedElement -> Effect String
+foreign import setType :: String -> HTMLEmbedElement -> Effect Unit
 
-foreign import width :: forall eff. HTMLEmbedElement -> Eff (dom :: DOM | eff) String
-foreign import setWidth :: forall eff. String -> HTMLEmbedElement -> Eff (dom :: DOM | eff) Unit
+foreign import width :: HTMLEmbedElement -> Effect String
+foreign import setWidth :: String -> HTMLEmbedElement -> Effect Unit
 
-foreign import height :: forall eff. HTMLEmbedElement -> Eff (dom :: DOM | eff) String
-foreign import setHeight :: forall eff. String -> HTMLEmbedElement -> Eff (dom :: DOM | eff) Unit
+foreign import height :: HTMLEmbedElement -> Effect String
+foreign import setHeight :: String -> HTMLEmbedElement -> Effect Unit

--- a/src/DOM/HTML/HTMLFieldSetElement.purs
+++ b/src/DOM/HTML/HTMLFieldSetElement.purs
@@ -15,36 +15,35 @@ module DOM.HTML.HTMLFieldSetElement
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLFieldSetElement, HTMLFormElement, ValidityState)
 
-foreign import disabled :: forall eff. HTMLFieldSetElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setDisabled :: forall eff. Boolean -> HTMLFieldSetElement -> Eff (dom :: DOM | eff) Unit
+foreign import disabled :: HTMLFieldSetElement -> Effect Boolean
+foreign import setDisabled :: Boolean -> HTMLFieldSetElement -> Effect Unit
 
-foreign import _form :: forall eff. HTMLFieldSetElement -> Eff (dom :: DOM | eff) (Nullable HTMLFormElement)
+foreign import _form :: HTMLFieldSetElement -> Effect (Nullable HTMLFormElement)
 
-form :: forall eff. HTMLFieldSetElement -> Eff (dom :: DOM | eff) (Maybe HTMLFormElement)
+form :: HTMLFieldSetElement -> Effect (Maybe HTMLFormElement)
 form = map toMaybe <<< _form
 
-foreign import name :: forall eff. HTMLFieldSetElement -> Eff (dom :: DOM | eff) String
-foreign import setName :: forall eff. String -> HTMLFieldSetElement -> Eff (dom :: DOM | eff) Unit
+foreign import name :: HTMLFieldSetElement -> Effect String
+foreign import setName :: String -> HTMLFieldSetElement -> Effect Unit
 
-foreign import type_ :: forall eff. HTMLFieldSetElement -> Eff (dom :: DOM | eff) String
-foreign import setType :: forall eff. String -> HTMLFieldSetElement -> Eff (dom :: DOM | eff) Unit
+foreign import type_ :: HTMLFieldSetElement -> Effect String
+foreign import setType :: String -> HTMLFieldSetElement -> Effect Unit
 
 --   readonly attribute HTMLFormControlsCollection elements;
 
-foreign import willValidate :: forall eff. HTMLFieldSetElement -> Eff (dom :: DOM | eff) Boolean
+foreign import willValidate :: HTMLFieldSetElement -> Effect Boolean
 
-foreign import validity :: forall eff. HTMLFieldSetElement -> Eff (dom :: DOM | eff) ValidityState
+foreign import validity :: HTMLFieldSetElement -> Effect ValidityState
 
-foreign import validationMessage :: forall eff. HTMLFieldSetElement -> Eff (dom :: DOM | eff) String
+foreign import validationMessage :: HTMLFieldSetElement -> Effect String
 
-foreign import checkValidity :: forall eff. HTMLFieldSetElement -> Eff (dom :: DOM | eff) Boolean
+foreign import checkValidity :: HTMLFieldSetElement -> Effect Boolean
 
-foreign import setCustomValidity :: forall eff. String -> HTMLFieldSetElement -> Eff (dom :: DOM | eff) Unit
+foreign import setCustomValidity :: String -> HTMLFieldSetElement -> Effect Unit

--- a/src/DOM/HTML/HTMLFormElement.purs
+++ b/src/DOM/HTML/HTMLFormElement.purs
@@ -2,45 +2,44 @@ module DOM.HTML.HTMLFormElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLFormElement)
 
-foreign import acceptCharset :: forall eff. HTMLFormElement -> Eff (dom :: DOM | eff) String
-foreign import setAcceptCharset :: forall eff. String -> HTMLFormElement -> Eff (dom :: DOM | eff) Unit
+foreign import acceptCharset :: HTMLFormElement -> Effect String
+foreign import setAcceptCharset :: String -> HTMLFormElement -> Effect Unit
 
-foreign import action :: forall eff. HTMLFormElement -> Eff (dom :: DOM | eff) String
-foreign import setAction :: forall eff. String -> HTMLFormElement -> Eff (dom :: DOM | eff) Unit
+foreign import action :: HTMLFormElement -> Effect String
+foreign import setAction :: String -> HTMLFormElement -> Effect Unit
 
-foreign import autocomplete :: forall eff. HTMLFormElement -> Eff (dom :: DOM | eff) String
-foreign import setAutocomplete :: forall eff. String -> HTMLFormElement -> Eff (dom :: DOM | eff) Unit
+foreign import autocomplete :: HTMLFormElement -> Effect String
+foreign import setAutocomplete :: String -> HTMLFormElement -> Effect Unit
 
-foreign import enctype :: forall eff. HTMLFormElement -> Eff (dom :: DOM | eff) String
-foreign import setEnctype :: forall eff. String -> HTMLFormElement -> Eff (dom :: DOM | eff) Unit
+foreign import enctype :: HTMLFormElement -> Effect String
+foreign import setEnctype :: String -> HTMLFormElement -> Effect Unit
 
-foreign import encoding :: forall eff. HTMLFormElement -> Eff (dom :: DOM | eff) String
-foreign import setEncoding :: forall eff. String -> HTMLFormElement -> Eff (dom :: DOM | eff) Unit
+foreign import encoding :: HTMLFormElement -> Effect String
+foreign import setEncoding :: String -> HTMLFormElement -> Effect Unit
 
-foreign import method :: forall eff. HTMLFormElement -> Eff (dom :: DOM | eff) String
-foreign import setMethod :: forall eff. String -> HTMLFormElement -> Eff (dom :: DOM | eff) Unit
+foreign import method :: HTMLFormElement -> Effect String
+foreign import setMethod :: String -> HTMLFormElement -> Effect Unit
 
-foreign import name :: forall eff. HTMLFormElement -> Eff (dom :: DOM | eff) String
-foreign import setName :: forall eff. String -> HTMLFormElement -> Eff (dom :: DOM | eff) Unit
+foreign import name :: HTMLFormElement -> Effect String
+foreign import setName :: String -> HTMLFormElement -> Effect Unit
 
-foreign import noValidate :: forall eff. HTMLFormElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setNoValidate :: forall eff. Boolean -> HTMLFormElement -> Eff (dom :: DOM | eff) Unit
+foreign import noValidate :: HTMLFormElement -> Effect Boolean
+foreign import setNoValidate :: Boolean -> HTMLFormElement -> Effect Unit
 
-foreign import target :: forall eff. HTMLFormElement -> Eff (dom :: DOM | eff) String
-foreign import setTarget :: forall eff. String -> HTMLFormElement -> Eff (dom :: DOM | eff) Unit
+foreign import target :: HTMLFormElement -> Effect String
+foreign import setTarget :: String -> HTMLFormElement -> Effect Unit
 
 --   readonly attribute HTMLFormControlsCollection elements;
 
-foreign import length :: forall eff. HTMLFormElement -> Eff (dom :: DOM | eff) Int
+foreign import length :: HTMLFormElement -> Effect Int
 
 --   getter Element (unsigned long index);
 --   getter (RadioNodeList or Element) (DOMString name);
 
-foreign import submit :: forall eff. HTMLFormElement -> Eff (dom :: DOM | eff) Unit
-foreign import reset :: forall eff. HTMLFormElement -> Eff (dom :: DOM | eff) Unit
-foreign import checkValidity :: forall eff. HTMLFormElement -> Eff (dom :: DOM | eff) Boolean
+foreign import submit :: HTMLFormElement -> Effect Unit
+foreign import reset :: HTMLFormElement -> Effect Unit
+foreign import checkValidity :: HTMLFormElement -> Effect Boolean

--- a/src/DOM/HTML/HTMLIFrameElement.purs
+++ b/src/DOM/HTML/HTMLIFrameElement.purs
@@ -15,37 +15,36 @@ module DOM.HTML.HTMLIFrameElement
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 
-import DOM (DOM)
 import DOM.HTML.Types (Window, HTMLIFrameElement)
 import DOM.Node.Types (Document)
 
-foreign import src :: forall eff. HTMLIFrameElement -> Eff (dom :: DOM | eff) String
-foreign import setSrc :: forall eff. String -> HTMLIFrameElement -> Eff (dom :: DOM | eff) Unit
+foreign import src :: HTMLIFrameElement -> Effect String
+foreign import setSrc :: String -> HTMLIFrameElement -> Effect Unit
 
-foreign import srcdoc :: forall eff. HTMLIFrameElement -> Eff (dom :: DOM | eff) String
-foreign import setSrcdoc :: forall eff. String -> HTMLIFrameElement -> Eff (dom :: DOM | eff) Unit
+foreign import srcdoc :: HTMLIFrameElement -> Effect String
+foreign import setSrcdoc :: String -> HTMLIFrameElement -> Effect Unit
 
-foreign import name :: forall eff. HTMLIFrameElement -> Eff (dom :: DOM | eff) String
-foreign import setName :: forall eff. String -> HTMLIFrameElement -> Eff (dom :: DOM | eff) Unit
+foreign import name :: HTMLIFrameElement -> Effect String
+foreign import setName :: String -> HTMLIFrameElement -> Effect Unit
 
 --   [PutForwards=value] readonly attribute DOMSettableTokenList sandbox;
 
-foreign import width :: forall eff. HTMLIFrameElement -> Eff (dom :: DOM | eff) String
-foreign import setWidth :: forall eff. String -> HTMLIFrameElement -> Eff (dom :: DOM | eff) Unit
+foreign import width :: HTMLIFrameElement -> Effect String
+foreign import setWidth :: String -> HTMLIFrameElement -> Effect Unit
 
-foreign import height :: forall eff. HTMLIFrameElement -> Eff (dom :: DOM | eff) String
-foreign import setHeight :: forall eff. String -> HTMLIFrameElement -> Eff (dom :: DOM | eff) Unit
+foreign import height :: HTMLIFrameElement -> Effect String
+foreign import setHeight :: String -> HTMLIFrameElement -> Effect Unit
 
-foreign import _contentDocument :: forall eff. HTMLIFrameElement -> Eff (dom :: DOM | eff) (Nullable Document)
-foreign import _contentWindow :: forall eff. HTMLIFrameElement -> Eff (dom :: DOM | eff) (Nullable Window)
+foreign import _contentDocument :: HTMLIFrameElement -> Effect (Nullable Document)
+foreign import _contentWindow :: HTMLIFrameElement -> Effect (Nullable Window)
 
-contentDocument :: forall eff. HTMLIFrameElement -> Eff (dom :: DOM | eff) (Maybe Document)
+contentDocument :: HTMLIFrameElement -> Effect (Maybe Document)
 contentDocument = map toMaybe <<< _contentDocument
 
-contentWindow :: forall eff. HTMLIFrameElement -> Eff (dom :: DOM | eff) (Maybe Window)
+contentWindow :: HTMLIFrameElement -> Effect (Maybe Window)
 contentWindow = map toMaybe <<< _contentWindow

--- a/src/DOM/HTML/HTMLImageElement.purs
+++ b/src/DOM/HTML/HTMLImageElement.purs
@@ -2,35 +2,34 @@ module DOM.HTML.HTMLImageElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLImageElement)
 
-foreign import create :: forall eff. Unit -> Eff (dom :: DOM | eff) HTMLImageElement
-foreign import create' :: forall eff. Int -> Int -> Eff (dom :: DOM | eff) HTMLImageElement
+foreign import create :: Unit -> Effect HTMLImageElement
+foreign import create' :: Int -> Int -> Effect HTMLImageElement
 
-foreign import alt :: forall eff. HTMLImageElement -> Eff (dom :: DOM | eff) String
-foreign import setAlt :: forall eff. String -> HTMLImageElement -> Eff (dom :: DOM | eff) Unit
+foreign import alt :: HTMLImageElement -> Effect String
+foreign import setAlt :: String -> HTMLImageElement -> Effect Unit
 
-foreign import src :: forall eff. HTMLImageElement -> Eff (dom :: DOM | eff) String
-foreign import setSrc :: forall eff. String -> HTMLImageElement -> Eff (dom :: DOM | eff) Unit
+foreign import src :: HTMLImageElement -> Effect String
+foreign import setSrc :: String -> HTMLImageElement -> Effect Unit
 
-foreign import crossOrigin :: forall eff. HTMLImageElement -> Eff (dom :: DOM | eff) String
-foreign import setCrossOrigin :: forall eff. String -> HTMLImageElement -> Eff (dom :: DOM | eff) Unit
+foreign import crossOrigin :: HTMLImageElement -> Effect String
+foreign import setCrossOrigin :: String -> HTMLImageElement -> Effect Unit
 
-foreign import useMap :: forall eff. HTMLImageElement -> Eff (dom :: DOM | eff) String
-foreign import setUseMap :: forall eff. String -> HTMLImageElement -> Eff (dom :: DOM | eff) Unit
+foreign import useMap :: HTMLImageElement -> Effect String
+foreign import setUseMap :: String -> HTMLImageElement -> Effect Unit
 
-foreign import isMap :: forall eff. HTMLImageElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setIsMap :: forall eff. Boolean -> HTMLImageElement -> Eff (dom :: DOM | eff) Unit
+foreign import isMap :: HTMLImageElement -> Effect Boolean
+foreign import setIsMap :: Boolean -> HTMLImageElement -> Effect Unit
 
-foreign import width :: forall eff. HTMLImageElement -> Eff (dom :: DOM | eff) Int
-foreign import setWidth :: forall eff. Int -> HTMLImageElement -> Eff (dom :: DOM | eff) Unit
+foreign import width :: HTMLImageElement -> Effect Int
+foreign import setWidth :: Int -> HTMLImageElement -> Effect Unit
 
-foreign import height :: forall eff. HTMLImageElement -> Eff (dom :: DOM | eff) Int
-foreign import setHeight :: forall eff. Int -> HTMLImageElement -> Eff (dom :: DOM | eff) Unit
+foreign import height :: HTMLImageElement -> Effect Int
+foreign import setHeight :: Int -> HTMLImageElement -> Effect Unit
 
-foreign import naturalWidth :: forall eff. HTMLImageElement -> Eff (dom :: DOM | eff) Int
-foreign import naturalHeight :: forall eff. HTMLImageElement -> Eff (dom :: DOM | eff) Int
-foreign import complete :: forall eff. HTMLImageElement -> Eff (dom :: DOM | eff) Boolean
+foreign import naturalWidth :: HTMLImageElement -> Effect Int
+foreign import naturalHeight :: HTMLImageElement -> Effect Int
+foreign import complete :: HTMLImageElement -> Effect Boolean

--- a/src/DOM/HTML/HTMLInputElement.purs
+++ b/src/DOM/HTML/HTMLInputElement.purs
@@ -91,167 +91,167 @@ module DOM.HTML.HTMLInputElement
   ) where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 import Data.JSDate (JSDate)
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
-import DOM (DOM)
+
 import DOM.File.Types (FileList)
 import DOM.HTML.SelectionMode (SelectionMode)
 import DOM.HTML.Types (HTMLElement, HTMLInputElement, HTMLFormElement, ValidityState)
 import DOM.Node.Types (NodeList)
 
-foreign import accept :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setAccept :: forall eff. Boolean -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import accept :: HTMLInputElement -> Effect Boolean
+foreign import setAccept :: Boolean -> HTMLInputElement -> Effect Unit
 
-foreign import alt :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setAlt :: forall eff. Boolean -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import alt :: HTMLInputElement -> Effect Boolean
+foreign import setAlt :: Boolean -> HTMLInputElement -> Effect Unit
 
-foreign import autocomplete :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setAutocomplete :: forall eff. Boolean -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import autocomplete :: HTMLInputElement -> Effect Boolean
+foreign import setAutocomplete :: Boolean -> HTMLInputElement -> Effect Unit
 
-foreign import autofocus :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setAutofocus :: forall eff. Boolean -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import autofocus :: HTMLInputElement -> Effect Boolean
+foreign import setAutofocus :: Boolean -> HTMLInputElement -> Effect Unit
 
-foreign import defaultChecked :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setDefaultChecked :: forall eff. Boolean -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import defaultChecked :: HTMLInputElement -> Effect Boolean
+foreign import setDefaultChecked :: Boolean -> HTMLInputElement -> Effect Unit
 
-foreign import checked :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setChecked :: forall eff. Boolean -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import checked :: HTMLInputElement -> Effect Boolean
+foreign import setChecked :: Boolean -> HTMLInputElement -> Effect Unit
 
-foreign import dirName :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) String
-foreign import setDirName :: forall eff. String -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import dirName :: HTMLInputElement -> Effect String
+foreign import setDirName :: String -> HTMLInputElement -> Effect Unit
 
-foreign import disabled :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setDisabled :: forall eff. Boolean -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import disabled :: HTMLInputElement -> Effect Boolean
+foreign import setDisabled :: Boolean -> HTMLInputElement -> Effect Unit
 
-form :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) (Maybe HTMLFormElement)
+form :: HTMLInputElement -> Effect (Maybe HTMLFormElement)
 form = map toMaybe <<< _form
 
-foreign import _form :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) (Nullable HTMLFormElement)
+foreign import _form :: HTMLInputElement -> Effect (Nullable HTMLFormElement)
 
-files :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) (Maybe FileList)
+files :: HTMLInputElement -> Effect (Maybe FileList)
 files = map toMaybe <<< _files
 
-foreign import _files :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) (Nullable FileList)
+foreign import _files :: HTMLInputElement -> Effect (Nullable FileList)
 
-foreign import formAction :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) String
-foreign import setFormAction :: forall eff. String -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import formAction :: HTMLInputElement -> Effect String
+foreign import setFormAction :: String -> HTMLInputElement -> Effect Unit
 
-foreign import formEnctype :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) String
-foreign import setFormEnctype :: forall eff. String -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import formEnctype :: HTMLInputElement -> Effect String
+foreign import setFormEnctype :: String -> HTMLInputElement -> Effect Unit
 
-foreign import formMethod :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) String
-foreign import setFormMethod :: forall eff. String -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import formMethod :: HTMLInputElement -> Effect String
+foreign import setFormMethod :: String -> HTMLInputElement -> Effect Unit
 
-foreign import formNoValidate :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setFormNoValidate :: forall eff. Boolean -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import formNoValidate :: HTMLInputElement -> Effect Boolean
+foreign import setFormNoValidate :: Boolean -> HTMLInputElement -> Effect Unit
 
-foreign import formTarget :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) String
-foreign import setFormTarget :: forall eff. String -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import formTarget :: HTMLInputElement -> Effect String
+foreign import setFormTarget :: String -> HTMLInputElement -> Effect Unit
 
-foreign import height :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Int
-foreign import setHeight :: forall eff. Int -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import height :: HTMLInputElement -> Effect Int
+foreign import setHeight :: Int -> HTMLInputElement -> Effect Unit
 
-foreign import indeterminate :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setIndeterminate :: forall eff. Boolean -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import indeterminate :: HTMLInputElement -> Effect Boolean
+foreign import setIndeterminate :: Boolean -> HTMLInputElement -> Effect Unit
 
-list :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) (Maybe HTMLElement)
+list :: HTMLInputElement -> Effect (Maybe HTMLElement)
 list = map toMaybe <<< _list
 
-foreign import _list :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) (Nullable HTMLElement)
+foreign import _list :: HTMLInputElement -> Effect (Nullable HTMLElement)
 
-foreign import max :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) String
-foreign import setMax :: forall eff. String -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import max :: HTMLInputElement -> Effect String
+foreign import setMax :: String -> HTMLInputElement -> Effect Unit
 
-foreign import maxLength :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Int
-foreign import setMaxLength :: forall eff. Int -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import maxLength :: HTMLInputElement -> Effect Int
+foreign import setMaxLength :: Int -> HTMLInputElement -> Effect Unit
 
-foreign import min :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) String
-foreign import setMin :: forall eff. String -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import min :: HTMLInputElement -> Effect String
+foreign import setMin :: String -> HTMLInputElement -> Effect Unit
 
-foreign import minLength :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Int
-foreign import setMinLength :: forall eff. Int -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import minLength :: HTMLInputElement -> Effect Int
+foreign import setMinLength :: Int -> HTMLInputElement -> Effect Unit
 
-foreign import multiple :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setMultiple :: forall eff. Boolean -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import multiple :: HTMLInputElement -> Effect Boolean
+foreign import setMultiple :: Boolean -> HTMLInputElement -> Effect Unit
 
-foreign import name :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) String
-foreign import setName :: forall eff. String -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import name :: HTMLInputElement -> Effect String
+foreign import setName :: String -> HTMLInputElement -> Effect Unit
 
-foreign import pattern :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) String
-foreign import setPattern :: forall eff. String -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import pattern :: HTMLInputElement -> Effect String
+foreign import setPattern :: String -> HTMLInputElement -> Effect Unit
 
-foreign import placeholder :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) String
-foreign import setPlaceholder :: forall eff. String -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import placeholder :: HTMLInputElement -> Effect String
+foreign import setPlaceholder :: String -> HTMLInputElement -> Effect Unit
 
-foreign import readOnly :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setReadOnly :: forall eff. Boolean -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import readOnly :: HTMLInputElement -> Effect Boolean
+foreign import setReadOnly :: Boolean -> HTMLInputElement -> Effect Unit
 
-foreign import required :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setRequired :: forall eff. Boolean -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import required :: HTMLInputElement -> Effect Boolean
+foreign import setRequired :: Boolean -> HTMLInputElement -> Effect Unit
 
-foreign import size :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Int
-foreign import setSize :: forall eff. Int -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import size :: HTMLInputElement -> Effect Int
+foreign import setSize :: Int -> HTMLInputElement -> Effect Unit
 
-foreign import src :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) String
-foreign import setSrc :: forall eff. String -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import src :: HTMLInputElement -> Effect String
+foreign import setSrc :: String -> HTMLInputElement -> Effect Unit
 
-foreign import step :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) String
-foreign import setStep :: forall eff. String -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import step :: HTMLInputElement -> Effect String
+foreign import setStep :: String -> HTMLInputElement -> Effect Unit
 
-foreign import type_ :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) String
-foreign import setType :: forall eff. String -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import type_ :: HTMLInputElement -> Effect String
+foreign import setType :: String -> HTMLInputElement -> Effect Unit
 
-foreign import defaultValue :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) String
-foreign import setDefaultValue :: forall eff. String -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import defaultValue :: HTMLInputElement -> Effect String
+foreign import setDefaultValue :: String -> HTMLInputElement -> Effect Unit
 
-foreign import value :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) String
-foreign import setValue :: forall eff. String -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import value :: HTMLInputElement -> Effect String
+foreign import setValue :: String -> HTMLInputElement -> Effect Unit
 
-foreign import valueAsDate :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) JSDate
-foreign import setValueAsDate :: forall eff. JSDate -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import valueAsDate :: HTMLInputElement -> Effect JSDate
+foreign import setValueAsDate :: JSDate -> HTMLInputElement -> Effect Unit
 
-foreign import valueAsNumber :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Number
-foreign import setValueAsNumber :: forall eff. Number -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import valueAsNumber :: HTMLInputElement -> Effect Number
+foreign import setValueAsNumber :: Number -> HTMLInputElement -> Effect Unit
 
-foreign import width :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Int
-foreign import setWidth :: forall eff. Int -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import width :: HTMLInputElement -> Effect Int
+foreign import setWidth :: Int -> HTMLInputElement -> Effect Unit
 
-stepUp :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+stepUp :: HTMLInputElement -> Effect Unit
 stepUp = stepUp' 1
 
-foreign import stepUp' :: forall eff. Int -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import stepUp' :: Int -> HTMLInputElement -> Effect Unit
 
-stepDown :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+stepDown :: HTMLInputElement -> Effect Unit
 stepDown = stepDown' 1
 
-foreign import stepDown' :: forall eff. Int -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import stepDown' :: Int -> HTMLInputElement -> Effect Unit
 
-foreign import willValidate :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Boolean
+foreign import willValidate :: HTMLInputElement -> Effect Boolean
 
-foreign import validity :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) ValidityState
+foreign import validity :: HTMLInputElement -> Effect ValidityState
 
-foreign import validationMessage :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) String
+foreign import validationMessage :: HTMLInputElement -> Effect String
 
-foreign import checkValidity :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Boolean
+foreign import checkValidity :: HTMLInputElement -> Effect Boolean
 
-foreign import setCustomValidity :: forall eff. String -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import setCustomValidity :: String -> HTMLInputElement -> Effect Unit
 
-foreign import labels :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) NodeList
+foreign import labels :: HTMLInputElement -> Effect NodeList
 
-foreign import select :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import select :: HTMLInputElement -> Effect Unit
 
-foreign import selectionStart :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Int
-foreign import setSelectionStart :: forall eff. Int -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import selectionStart :: HTMLInputElement -> Effect Int
+foreign import setSelectionStart :: Int -> HTMLInputElement -> Effect Unit
 
-foreign import selectionEnd :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) Int
-foreign import setSelectionEnd :: forall eff. Int -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import selectionEnd :: HTMLInputElement -> Effect Int
+foreign import setSelectionEnd :: Int -> HTMLInputElement -> Effect Unit
 
-foreign import selectionDirection :: forall eff. HTMLInputElement -> Eff (dom :: DOM | eff) String
-foreign import setSelectionDirection :: forall eff. String -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import selectionDirection :: HTMLInputElement -> Effect String
+foreign import setSelectionDirection :: String -> HTMLInputElement -> Effect Unit
 
-foreign import setRangeText :: forall eff. String -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
-foreign import setRangeText' :: forall eff. String -> Int -> Int -> SelectionMode -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import setRangeText :: String -> HTMLInputElement -> Effect Unit
+foreign import setRangeText' :: String -> Int -> Int -> SelectionMode -> HTMLInputElement -> Effect Unit
 
-foreign import setSelectionRange :: forall eff. Int -> Int -> String -> HTMLInputElement -> Eff (dom :: DOM | eff) Unit
+foreign import setSelectionRange :: Int -> Int -> String -> HTMLInputElement -> Effect Unit

--- a/src/DOM/HTML/HTMLKeygenElement.purs
+++ b/src/DOM/HTML/HTMLKeygenElement.purs
@@ -21,45 +21,44 @@ module DOM.HTML.HTMLKeygenElement
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 
-import DOM (DOM)
 import DOM.Node.Types (NodeList)
 import DOM.HTML.Types (HTMLKeygenElement, HTMLFormElement, ValidityState)
 
-foreign import autofocus :: forall eff. HTMLKeygenElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setAutofocus :: forall eff. Boolean -> HTMLKeygenElement -> Eff (dom :: DOM | eff) Unit
+foreign import autofocus :: HTMLKeygenElement -> Effect Boolean
+foreign import setAutofocus :: Boolean -> HTMLKeygenElement -> Effect Unit
 
-foreign import challenge :: forall eff. HTMLKeygenElement -> Eff (dom :: DOM | eff) String
-foreign import setChallenge :: forall eff. String -> HTMLKeygenElement -> Eff (dom :: DOM | eff) Unit
+foreign import challenge :: HTMLKeygenElement -> Effect String
+foreign import setChallenge :: String -> HTMLKeygenElement -> Effect Unit
 
-foreign import disabled :: forall eff. HTMLKeygenElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setDisabled :: forall eff. Boolean -> HTMLKeygenElement -> Eff (dom :: DOM | eff) Unit
+foreign import disabled :: HTMLKeygenElement -> Effect Boolean
+foreign import setDisabled :: Boolean -> HTMLKeygenElement -> Effect Unit
 
-form :: forall eff. HTMLKeygenElement -> Eff (dom :: DOM | eff) (Maybe HTMLFormElement)
+form :: HTMLKeygenElement -> Effect (Maybe HTMLFormElement)
 form = map toMaybe <<< _form
 
-foreign import _form :: forall eff. HTMLKeygenElement -> Eff (dom :: DOM | eff) (Nullable HTMLFormElement)
+foreign import _form :: HTMLKeygenElement -> Effect (Nullable HTMLFormElement)
 
-foreign import keytype :: forall eff. HTMLKeygenElement -> Eff (dom :: DOM | eff) String
-foreign import setKeytype :: forall eff. String -> HTMLKeygenElement -> Eff (dom :: DOM | eff) Unit
+foreign import keytype :: HTMLKeygenElement -> Effect String
+foreign import setKeytype :: String -> HTMLKeygenElement -> Effect Unit
 
-foreign import name :: forall eff. HTMLKeygenElement -> Eff (dom :: DOM | eff) String
-foreign import setName :: forall eff. String -> HTMLKeygenElement -> Eff (dom :: DOM | eff) Unit
+foreign import name :: HTMLKeygenElement -> Effect String
+foreign import setName :: String -> HTMLKeygenElement -> Effect Unit
 
-foreign import type_ :: forall eff. HTMLKeygenElement -> Eff (dom :: DOM | eff) String
+foreign import type_ :: HTMLKeygenElement -> Effect String
 
-foreign import willValidate :: forall eff. HTMLKeygenElement -> Eff (dom :: DOM | eff) Boolean
+foreign import willValidate :: HTMLKeygenElement -> Effect Boolean
 
-foreign import validity :: forall eff. HTMLKeygenElement -> Eff (dom :: DOM | eff) ValidityState
+foreign import validity :: HTMLKeygenElement -> Effect ValidityState
 
-foreign import validationMessage :: forall eff. HTMLKeygenElement -> Eff (dom :: DOM | eff) String
+foreign import validationMessage :: HTMLKeygenElement -> Effect String
 
-foreign import checkValidity :: forall eff. HTMLKeygenElement -> Eff (dom :: DOM | eff) Boolean
+foreign import checkValidity :: HTMLKeygenElement -> Effect Boolean
 
-foreign import setCustomValidity :: forall eff. String -> HTMLKeygenElement -> Eff (dom :: DOM | eff) Unit
+foreign import setCustomValidity :: String -> HTMLKeygenElement -> Effect Unit
 
-foreign import labels :: forall eff. HTMLKeygenElement -> Eff (dom :: DOM | eff) NodeList
+foreign import labels :: HTMLKeygenElement -> Effect NodeList

--- a/src/DOM/HTML/HTMLLIElement.purs
+++ b/src/DOM/HTML/HTMLLIElement.purs
@@ -2,10 +2,9 @@ module DOM.HTML.HTMLLIElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLLIElement)
 
-foreign import value :: forall eff. HTMLLIElement -> Eff (dom :: DOM | eff) Int
-foreign import setValue :: forall eff. Int -> HTMLLIElement -> Eff (dom :: DOM | eff) Unit
+foreign import value :: HTMLLIElement -> Effect Int
+foreign import setValue :: Int -> HTMLLIElement -> Effect Unit

--- a/src/DOM/HTML/HTMLLabelElement.purs
+++ b/src/DOM/HTML/HTMLLabelElement.purs
@@ -7,23 +7,22 @@ module DOM.HTML.HTMLLabelElement
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLLabelElement, HTMLFormElement, HTMLElement)
 
-form :: forall eff. HTMLLabelElement -> Eff (dom :: DOM | eff) (Maybe HTMLFormElement)
+form :: HTMLLabelElement -> Effect (Maybe HTMLFormElement)
 form = map toMaybe <<< _form
 
-foreign import _form :: forall eff. HTMLLabelElement -> Eff (dom :: DOM | eff) (Nullable HTMLFormElement)
+foreign import _form :: HTMLLabelElement -> Effect (Nullable HTMLFormElement)
 
-foreign import htmlFor :: forall eff. HTMLLabelElement -> Eff (dom :: DOM | eff) String
-foreign import setHtmlFor :: forall eff. String -> HTMLLabelElement -> Eff (dom :: DOM | eff) Unit
+foreign import htmlFor :: HTMLLabelElement -> Effect String
+foreign import setHtmlFor :: String -> HTMLLabelElement -> Effect Unit
 
-control :: forall eff. HTMLLabelElement -> Eff (dom :: DOM | eff) (Maybe HTMLElement)
+control :: HTMLLabelElement -> Effect (Maybe HTMLElement)
 control = map toMaybe <<< _control
 
-foreign import _control :: forall eff. HTMLLabelElement -> Eff (dom :: DOM | eff) (Nullable HTMLElement)
+foreign import _control :: HTMLLabelElement -> Effect (Nullable HTMLElement)

--- a/src/DOM/HTML/HTMLLegendElement.purs
+++ b/src/DOM/HTML/HTMLLegendElement.purs
@@ -4,14 +4,13 @@ module DOM.HTML.HTMLLegendElement
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLLegendElement, HTMLFormElement)
 
-form :: forall eff. HTMLLegendElement -> Eff (dom :: DOM | eff) (Maybe HTMLFormElement)
+form :: HTMLLegendElement -> Effect (Maybe HTMLFormElement)
 form = map toMaybe <<< _form
 
-foreign import _form :: forall eff. HTMLLegendElement -> Eff (dom :: DOM | eff) (Nullable HTMLFormElement)
+foreign import _form :: HTMLLegendElement -> Effect (Nullable HTMLFormElement)

--- a/src/DOM/HTML/HTMLLinkElement.purs
+++ b/src/DOM/HTML/HTMLLinkElement.purs
@@ -2,37 +2,36 @@ module DOM.HTML.HTMLLinkElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLLinkElement)
 import DOM.Node.Types (DOMTokenList)
 
-foreign import disabled :: forall eff. HTMLLinkElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setDisabled :: forall eff. Boolean -> HTMLLinkElement -> Eff (dom :: DOM | eff) Unit
+foreign import disabled :: HTMLLinkElement -> Effect Boolean
+foreign import setDisabled :: Boolean -> HTMLLinkElement -> Effect Unit
 
-foreign import href :: forall eff. HTMLLinkElement -> Eff (dom :: DOM | eff) String
-foreign import setHref :: forall eff. String -> HTMLLinkElement -> Eff (dom :: DOM | eff) Unit
+foreign import href :: HTMLLinkElement -> Effect String
+foreign import setHref :: String -> HTMLLinkElement -> Effect Unit
 
-foreign import crossOrigin :: forall eff. HTMLLinkElement -> Eff (dom :: DOM | eff) String
-foreign import setCrossOrigin :: forall eff. String -> HTMLLinkElement -> Eff (dom :: DOM | eff) Unit
+foreign import crossOrigin :: HTMLLinkElement -> Effect String
+foreign import setCrossOrigin :: String -> HTMLLinkElement -> Effect Unit
 
-foreign import rel :: forall eff. HTMLLinkElement -> Eff (dom :: DOM | eff) String
-foreign import setRel :: forall eff. String -> HTMLLinkElement -> Eff (dom :: DOM | eff) Unit
+foreign import rel :: HTMLLinkElement -> Effect String
+foreign import setRel :: String -> HTMLLinkElement -> Effect Unit
 
-foreign import rev :: forall eff. HTMLLinkElement -> Eff (dom :: DOM | eff) String
-foreign import setRev :: forall eff. String -> HTMLLinkElement -> Eff (dom :: DOM | eff) Unit
+foreign import rev :: HTMLLinkElement -> Effect String
+foreign import setRev :: String -> HTMLLinkElement -> Effect Unit
 
-foreign import relList :: forall eff. HTMLLinkElement -> Eff (dom :: DOM | eff) DOMTokenList
+foreign import relList :: HTMLLinkElement -> Effect DOMTokenList
 
-foreign import media :: forall eff. HTMLLinkElement -> Eff (dom :: DOM | eff) String
-foreign import setMedia :: forall eff. String -> HTMLLinkElement -> Eff (dom :: DOM | eff) Unit
+foreign import media :: HTMLLinkElement -> Effect String
+foreign import setMedia :: String -> HTMLLinkElement -> Effect Unit
 
-foreign import hreflang :: forall eff. HTMLLinkElement -> Eff (dom :: DOM | eff) String
-foreign import setHreflang :: forall eff. String -> HTMLLinkElement -> Eff (dom :: DOM | eff) Unit
+foreign import hreflang :: HTMLLinkElement -> Effect String
+foreign import setHreflang :: String -> HTMLLinkElement -> Effect Unit
 
-foreign import type_ :: forall eff. HTMLLinkElement -> Eff (dom :: DOM | eff) String
-foreign import setType :: forall eff. String -> HTMLLinkElement -> Eff (dom :: DOM | eff) Unit
+foreign import type_ :: HTMLLinkElement -> Effect String
+foreign import setType :: String -> HTMLLinkElement -> Effect Unit
 
 --   [PutForwards=value] readonly attribute DOMSettableTokenList sizes;
 

--- a/src/DOM/HTML/HTMLMapElement.purs
+++ b/src/DOM/HTML/HTMLMapElement.purs
@@ -2,15 +2,14 @@ module DOM.HTML.HTMLMapElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLMapElement)
 import DOM.Node.Types (HTMLCollection)
 
-foreign import name :: forall eff. HTMLMapElement -> Eff (dom :: DOM | eff) String
-foreign import setName :: forall eff. String -> HTMLMapElement -> Eff (dom :: DOM | eff) Unit
+foreign import name :: HTMLMapElement -> Effect String
+foreign import setName :: String -> HTMLMapElement -> Effect Unit
 
-foreign import areas :: forall eff. HTMLMapElement -> Eff (dom :: DOM | eff) HTMLCollection
+foreign import areas :: HTMLMapElement -> Effect HTMLCollection
 
-foreign import images :: forall eff. HTMLMapElement -> Eff (dom :: DOM | eff) HTMLCollection
+foreign import images :: HTMLMapElement -> Effect HTMLCollection

--- a/src/DOM/HTML/HTMLMediaElement.purs
+++ b/src/DOM/HTML/HTMLMediaElement.purs
@@ -2,13 +2,12 @@ module DOM.HTML.HTMLMediaElement where
 
 import Prelude (Unit, map, (<<<))
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
 import Data.JSDate (JSDate)
 import Data.Enum (toEnum)
 import Data.Maybe (fromJust)
 
-import DOM (DOM)
 import DOM.HTML.HTMLMediaElement.CanPlayType (CanPlayType)
 import DOM.HTML.HTMLMediaElement.NetworkState (NetworkState)
 import DOM.HTML.HTMLMediaElement.ReadyState (ReadyState)
@@ -16,81 +15,81 @@ import DOM.HTML.Types (HTMLMediaElement)
 
 --   readonly attribute MediaError? error;
 
-foreign import src :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) String
-foreign import setSrc :: forall eff. String -> HTMLMediaElement -> Eff (dom :: DOM | eff) Unit
+foreign import src :: HTMLMediaElement -> Effect String
+foreign import setSrc :: String -> HTMLMediaElement -> Effect Unit
 
-foreign import currentSrc :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) String
+foreign import currentSrc :: HTMLMediaElement -> Effect String
 
-foreign import crossOrigin :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) String
-foreign import setCrossOrigin :: forall eff. String -> HTMLMediaElement -> Eff (dom :: DOM | eff) Unit
+foreign import crossOrigin :: HTMLMediaElement -> Effect String
+foreign import setCrossOrigin :: String -> HTMLMediaElement -> Effect Unit
 
-networkState :: forall eff. Partial => HTMLMediaElement -> Eff (dom :: DOM | eff) NetworkState
+networkState :: Partial => HTMLMediaElement -> Effect NetworkState
 networkState = map (fromJust <<< toEnum) <<< readyStateIndex
 
-foreign import networkStateIndex :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) Int
+foreign import networkStateIndex :: HTMLMediaElement -> Effect Int
 
-foreign import preload :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) String
-foreign import setPreload :: forall eff. String -> HTMLMediaElement -> Eff (dom :: DOM | eff) Unit
+foreign import preload :: HTMLMediaElement -> Effect String
+foreign import setPreload :: String -> HTMLMediaElement -> Effect Unit
 
 --   readonly attribute TimeRanges buffered;
 
-foreign import load :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) Unit
+foreign import load :: HTMLMediaElement -> Effect Unit
 
-foreign import canPlayType :: forall eff. String -> HTMLMediaElement -> Eff (dom :: DOM | eff) CanPlayType
+foreign import canPlayType :: String -> HTMLMediaElement -> Effect CanPlayType
 
-readyState :: forall eff. Partial => HTMLMediaElement -> Eff (dom :: DOM | eff) ReadyState
+readyState :: Partial => HTMLMediaElement -> Effect ReadyState
 readyState = map (fromJust <<< toEnum) <<< readyStateIndex
 
-foreign import readyStateIndex :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) Int
+foreign import readyStateIndex :: HTMLMediaElement -> Effect Int
 
-foreign import seeking :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) Boolean
+foreign import seeking :: HTMLMediaElement -> Effect Boolean
 
-foreign import currentTime :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) Number
-foreign import setCurrentTime :: forall eff. Number -> HTMLMediaElement -> Eff (dom :: DOM | eff) Unit
+foreign import currentTime :: HTMLMediaElement -> Effect Number
+foreign import setCurrentTime :: Number -> HTMLMediaElement -> Effect Unit
 
-foreign import duration :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) Number
+foreign import duration :: HTMLMediaElement -> Effect Number
 
-foreign import getStartDate :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) JSDate
+foreign import getStartDate :: HTMLMediaElement -> Effect JSDate
 
-foreign import paused :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) Boolean
+foreign import paused :: HTMLMediaElement -> Effect Boolean
 
-foreign import defaultPlaybackRate :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) Number
-foreign import setDefaultPlaybackRate :: forall eff. Number -> HTMLMediaElement -> Eff (dom :: DOM | eff) Unit
+foreign import defaultPlaybackRate :: HTMLMediaElement -> Effect Number
+foreign import setDefaultPlaybackRate :: Number -> HTMLMediaElement -> Effect Unit
 
-foreign import playbackRate :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) Number
-foreign import setPlaybackRate :: forall eff. Number -> HTMLMediaElement -> Eff (dom :: DOM | eff) Unit
+foreign import playbackRate :: HTMLMediaElement -> Effect Number
+foreign import setPlaybackRate :: Number -> HTMLMediaElement -> Effect Unit
 
 --   readonly attribute TimeRanges played;
 --   readonly attribute TimeRanges seekable;
 
-foreign import ended :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) Boolean
+foreign import ended :: HTMLMediaElement -> Effect Boolean
 
-foreign import autoplay :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setAutoplay :: forall eff. Boolean -> HTMLMediaElement -> Eff (dom :: DOM | eff) Unit
+foreign import autoplay :: HTMLMediaElement -> Effect Boolean
+foreign import setAutoplay :: Boolean -> HTMLMediaElement -> Effect Unit
 
-foreign import loop :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setLoop :: forall eff. Boolean -> HTMLMediaElement -> Eff (dom :: DOM | eff) Unit
+foreign import loop :: HTMLMediaElement -> Effect Boolean
+foreign import setLoop :: Boolean -> HTMLMediaElement -> Effect Unit
 
-foreign import play :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) Unit
+foreign import play :: HTMLMediaElement -> Effect Unit
 
-foreign import pause :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) Unit
+foreign import pause :: HTMLMediaElement -> Effect Unit
 
-foreign import mediaGroup :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) String
-foreign import setMediaGroup :: forall eff. String -> HTMLMediaElement -> Eff (dom :: DOM | eff) Unit
+foreign import mediaGroup :: HTMLMediaElement -> Effect String
+foreign import setMediaGroup :: String -> HTMLMediaElement -> Effect Unit
 
 --            attribute MediaController? controller;
 
-foreign import controls :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setControls :: forall eff. Boolean -> HTMLMediaElement -> Eff (dom :: DOM | eff) Unit
+foreign import controls :: HTMLMediaElement -> Effect Boolean
+foreign import setControls :: Boolean -> HTMLMediaElement -> Effect Unit
 
-foreign import volume :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) Number
-foreign import setVolume :: forall eff. Number -> HTMLMediaElement -> Eff (dom :: DOM | eff) Unit
+foreign import volume :: HTMLMediaElement -> Effect Number
+foreign import setVolume :: Number -> HTMLMediaElement -> Effect Unit
 
-foreign import muted :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setMuted :: forall eff. Boolean -> HTMLMediaElement -> Eff (dom :: DOM | eff) Unit
+foreign import muted :: HTMLMediaElement -> Effect Boolean
+foreign import setMuted :: Boolean -> HTMLMediaElement -> Effect Unit
 
-foreign import defaultMuted :: forall eff. HTMLMediaElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setDefaultMuted :: forall eff. Boolean -> HTMLMediaElement -> Eff (dom :: DOM | eff) Unit
+foreign import defaultMuted :: HTMLMediaElement -> Effect Boolean
+foreign import setDefaultMuted :: Boolean -> HTMLMediaElement -> Effect Unit
 
 --   readonly attribute AudioTrackList audioTracks;
 --   readonly attribute VideoTrackList videoTracks;

--- a/src/DOM/HTML/HTMLMetaElement.purs
+++ b/src/DOM/HTML/HTMLMetaElement.purs
@@ -2,16 +2,15 @@ module DOM.HTML.HTMLMetaElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLMetaElement)
 
-foreign import name :: forall eff. HTMLMetaElement -> Eff (dom :: DOM | eff) String
-foreign import setName :: forall eff. String -> HTMLMetaElement -> Eff (dom :: DOM | eff) Unit
+foreign import name :: HTMLMetaElement -> Effect String
+foreign import setName :: String -> HTMLMetaElement -> Effect Unit
 
-foreign import httpEquiv :: forall eff. HTMLMetaElement -> Eff (dom :: DOM | eff) String
-foreign import setHttpEquiv :: forall eff. String -> HTMLMetaElement -> Eff (dom :: DOM | eff) Unit
+foreign import httpEquiv :: HTMLMetaElement -> Effect String
+foreign import setHttpEquiv :: String -> HTMLMetaElement -> Effect Unit
 
-foreign import content :: forall eff. HTMLMetaElement -> Eff (dom :: DOM | eff) String
-foreign import setContent :: forall eff. String -> HTMLMetaElement -> Eff (dom :: DOM | eff) Unit
+foreign import content :: HTMLMetaElement -> Effect String
+foreign import setContent :: String -> HTMLMetaElement -> Effect Unit

--- a/src/DOM/HTML/HTMLMeterElement.purs
+++ b/src/DOM/HTML/HTMLMeterElement.purs
@@ -2,28 +2,27 @@ module DOM.HTML.HTMLMeterElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLMeterElement)
 import DOM.Node.Types (NodeList)
 
-foreign import value :: forall eff. HTMLMeterElement -> Eff (dom :: DOM | eff) Number
-foreign import setValue :: forall eff. Number -> HTMLMeterElement -> Eff (dom :: DOM | eff) Unit
+foreign import value :: HTMLMeterElement -> Effect Number
+foreign import setValue :: Number -> HTMLMeterElement -> Effect Unit
 
-foreign import min :: forall eff. HTMLMeterElement -> Eff (dom :: DOM | eff) Number
-foreign import setMin :: forall eff. Number -> HTMLMeterElement -> Eff (dom :: DOM | eff) Unit
+foreign import min :: HTMLMeterElement -> Effect Number
+foreign import setMin :: Number -> HTMLMeterElement -> Effect Unit
 
-foreign import max :: forall eff. HTMLMeterElement -> Eff (dom :: DOM | eff) Number
-foreign import setMax :: forall eff. Number -> HTMLMeterElement -> Eff (dom :: DOM | eff) Unit
+foreign import max :: HTMLMeterElement -> Effect Number
+foreign import setMax :: Number -> HTMLMeterElement -> Effect Unit
 
-foreign import low :: forall eff. HTMLMeterElement -> Eff (dom :: DOM | eff) Number
-foreign import setLow :: forall eff. Number -> HTMLMeterElement -> Eff (dom :: DOM | eff) Unit
+foreign import low :: HTMLMeterElement -> Effect Number
+foreign import setLow :: Number -> HTMLMeterElement -> Effect Unit
 
-foreign import high :: forall eff. HTMLMeterElement -> Eff (dom :: DOM | eff) Number
-foreign import setHigh :: forall eff. Number -> HTMLMeterElement -> Eff (dom :: DOM | eff) Unit
+foreign import high :: HTMLMeterElement -> Effect Number
+foreign import setHigh :: Number -> HTMLMeterElement -> Effect Unit
 
-foreign import optimum :: forall eff. HTMLMeterElement -> Eff (dom :: DOM | eff) Number
-foreign import setOptimum :: forall eff. Number -> HTMLMeterElement -> Eff (dom :: DOM | eff) Unit
+foreign import optimum :: HTMLMeterElement -> Effect Number
+foreign import setOptimum :: Number -> HTMLMeterElement -> Effect Unit
 
-foreign import labels :: forall eff. HTMLMeterElement -> Eff (dom :: DOM | eff) NodeList
+foreign import labels :: HTMLMeterElement -> Effect NodeList

--- a/src/DOM/HTML/HTMLModElement.purs
+++ b/src/DOM/HTML/HTMLModElement.purs
@@ -2,13 +2,12 @@ module DOM.HTML.HTMLModElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLModElement)
 
-foreign import cite :: forall eff. HTMLModElement -> Eff (dom :: DOM | eff) String
-foreign import setCite :: forall eff. String -> HTMLModElement -> Eff (dom :: DOM | eff) Unit
+foreign import cite :: HTMLModElement -> Effect String
+foreign import setCite :: String -> HTMLModElement -> Effect Unit
 
-foreign import dateTime :: forall eff. HTMLModElement -> Eff (dom :: DOM | eff) String
-foreign import setDateTime :: forall eff. String -> HTMLModElement -> Eff (dom :: DOM | eff) Unit
+foreign import dateTime :: HTMLModElement -> Effect String
+foreign import setDateTime :: String -> HTMLModElement -> Effect Unit

--- a/src/DOM/HTML/HTMLOListElement.purs
+++ b/src/DOM/HTML/HTMLOListElement.purs
@@ -2,16 +2,15 @@ module DOM.HTML.HTMLOListElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLOListElement)
 
-foreign import reversed :: forall eff. HTMLOListElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setReversed :: forall eff. Boolean -> HTMLOListElement -> Eff (dom :: DOM | eff) Unit
+foreign import reversed :: HTMLOListElement -> Effect Boolean
+foreign import setReversed :: Boolean -> HTMLOListElement -> Effect Unit
 
-foreign import start :: forall eff. HTMLOListElement -> Eff (dom :: DOM | eff) Int
-foreign import setStart :: forall eff. Int -> HTMLOListElement -> Eff (dom :: DOM | eff) Unit
+foreign import start :: HTMLOListElement -> Effect Int
+foreign import setStart :: Int -> HTMLOListElement -> Effect Unit
 
-foreign import type_ :: forall eff. HTMLOListElement -> Eff (dom :: DOM | eff) String
-foreign import setType :: forall eff. String -> HTMLOListElement -> Eff (dom :: DOM | eff) Unit
+foreign import type_ :: HTMLOListElement -> Effect String
+foreign import setType :: String -> HTMLOListElement -> Effect Unit

--- a/src/DOM/HTML/HTMLObjectElement.purs
+++ b/src/DOM/HTML/HTMLObjectElement.purs
@@ -23,55 +23,54 @@ module DOM.HTML.HTMLObjectElement
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLObjectElement, HTMLFormElement, ValidityState)
 import DOM.Node.Types (Document)
 
-foreign import data_ :: forall eff. HTMLObjectElement -> Eff (dom :: DOM | eff) String
-foreign import setData :: forall eff. String -> HTMLObjectElement -> Eff (dom :: DOM | eff) Unit
+foreign import data_ :: HTMLObjectElement -> Effect String
+foreign import setData :: String -> HTMLObjectElement -> Effect Unit
 
-foreign import type_ :: forall eff. HTMLObjectElement -> Eff (dom :: DOM | eff) String
-foreign import setType :: forall eff. String -> HTMLObjectElement -> Eff (dom :: DOM | eff) Unit
+foreign import type_ :: HTMLObjectElement -> Effect String
+foreign import setType :: String -> HTMLObjectElement -> Effect Unit
 
-foreign import typeMustMatch :: forall eff. HTMLObjectElement -> Eff (dom :: DOM | eff) Boolean
+foreign import typeMustMatch :: HTMLObjectElement -> Effect Boolean
 
-foreign import name :: forall eff. HTMLObjectElement -> Eff (dom :: DOM | eff) String
-foreign import setName :: forall eff. String -> HTMLObjectElement -> Eff (dom :: DOM | eff) Unit
+foreign import name :: HTMLObjectElement -> Effect String
+foreign import setName :: String -> HTMLObjectElement -> Effect Unit
 
-foreign import useMap :: forall eff. HTMLObjectElement -> Eff (dom :: DOM | eff) String
-foreign import setUseMap :: forall eff. String -> HTMLObjectElement -> Eff (dom :: DOM | eff) Unit
+foreign import useMap :: HTMLObjectElement -> Effect String
+foreign import setUseMap :: String -> HTMLObjectElement -> Effect Unit
 
-form :: forall eff. HTMLObjectElement -> Eff (dom :: DOM | eff) (Maybe HTMLFormElement)
+form :: HTMLObjectElement -> Effect (Maybe HTMLFormElement)
 form = map toMaybe <<< _form
 
-foreign import _form :: forall eff. HTMLObjectElement -> Eff (dom :: DOM | eff) (Nullable HTMLFormElement)
+foreign import _form :: HTMLObjectElement -> Effect (Nullable HTMLFormElement)
 
-foreign import width :: forall eff. HTMLObjectElement -> Eff (dom :: DOM | eff) String
-foreign import setWidth :: forall eff. String -> HTMLObjectElement -> Eff (dom :: DOM | eff) Unit
+foreign import width :: HTMLObjectElement -> Effect String
+foreign import setWidth :: String -> HTMLObjectElement -> Effect Unit
 
-foreign import height :: forall eff. HTMLObjectElement -> Eff (dom :: DOM | eff) String
-foreign import setHeight :: forall eff. String -> HTMLObjectElement -> Eff (dom :: DOM | eff) Unit
+foreign import height :: HTMLObjectElement -> Effect String
+foreign import setHeight :: String -> HTMLObjectElement -> Effect Unit
 
-contentDocument :: forall eff. HTMLObjectElement -> Eff (dom :: DOM | eff) (Maybe Document)
+contentDocument :: HTMLObjectElement -> Effect (Maybe Document)
 contentDocument = map toMaybe <<< _contentDocument
 
-foreign import _contentDocument :: forall eff. HTMLObjectElement -> Eff (dom :: DOM | eff) (Nullable Document)
+foreign import _contentDocument :: HTMLObjectElement -> Effect (Nullable Document)
 
 --   readonly attribute WindowProxy? contentWindow;
 
-foreign import willValidate :: forall eff. HTMLObjectElement -> Eff (dom :: DOM | eff) Boolean
+foreign import willValidate :: HTMLObjectElement -> Effect Boolean
 
-foreign import validity :: forall eff. HTMLObjectElement -> Eff (dom :: DOM | eff) ValidityState
+foreign import validity :: HTMLObjectElement -> Effect ValidityState
 
-foreign import validationMessage :: forall eff. HTMLObjectElement -> Eff (dom :: DOM | eff) String
+foreign import validationMessage :: HTMLObjectElement -> Effect String
 
-foreign import checkValidity :: forall eff. HTMLObjectElement -> Eff (dom :: DOM | eff) Boolean
+foreign import checkValidity :: HTMLObjectElement -> Effect Boolean
 
-foreign import setCustomValidity :: forall eff. String -> HTMLObjectElement -> Eff (dom :: DOM | eff) Unit
+foreign import setCustomValidity :: String -> HTMLObjectElement -> Effect Unit
 
 --   legacycaller any (any... arguments);

--- a/src/DOM/HTML/HTMLOptGroupElement.purs
+++ b/src/DOM/HTML/HTMLOptGroupElement.purs
@@ -2,13 +2,12 @@ module DOM.HTML.HTMLOptGroupElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLOptGroupElement)
 
-foreign import disabled :: forall eff. HTMLOptGroupElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setDisabled :: forall eff. Boolean -> HTMLOptGroupElement -> Eff (dom :: DOM | eff) Unit
+foreign import disabled :: HTMLOptGroupElement -> Effect Boolean
+foreign import setDisabled :: Boolean -> HTMLOptGroupElement -> Effect Unit
 
-foreign import label :: forall eff. HTMLOptGroupElement -> Eff (dom :: DOM | eff) String
-foreign import setLabel :: forall eff. String -> HTMLOptGroupElement -> Eff (dom :: DOM | eff) Unit
+foreign import label :: HTMLOptGroupElement -> Effect String
+foreign import setLabel :: String -> HTMLOptGroupElement -> Effect Unit

--- a/src/DOM/HTML/HTMLOptionElement.purs
+++ b/src/DOM/HTML/HTMLOptionElement.purs
@@ -17,37 +17,36 @@ module DOM.HTML.HTMLOptionElement
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLOptionElement, HTMLFormElement)
 
 -- [NamedConstructor=Option(optional DOMString text = "", optional DOMString value, optional boolean defaultSelected = false, optional boolean selected = false)]
 
-foreign import disabled :: forall eff. HTMLOptionElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setDisabled :: forall eff. Boolean -> HTMLOptionElement -> Eff (dom :: DOM | eff) Unit
+foreign import disabled :: HTMLOptionElement -> Effect Boolean
+foreign import setDisabled :: Boolean -> HTMLOptionElement -> Effect Unit
 
-form :: forall eff. HTMLOptionElement -> Eff (dom :: DOM | eff) (Maybe HTMLFormElement)
+form :: HTMLOptionElement -> Effect (Maybe HTMLFormElement)
 form = map toMaybe <<< _form
 
-foreign import _form :: forall eff. HTMLOptionElement -> Eff (dom :: DOM | eff) (Nullable HTMLFormElement)
+foreign import _form :: HTMLOptionElement -> Effect (Nullable HTMLFormElement)
 
-foreign import label :: forall eff. HTMLOptionElement -> Eff (dom :: DOM | eff) String
-foreign import setLabel :: forall eff. String -> HTMLOptionElement -> Eff (dom :: DOM | eff) Unit
+foreign import label :: HTMLOptionElement -> Effect String
+foreign import setLabel :: String -> HTMLOptionElement -> Effect Unit
 
-foreign import defaultSelected :: forall eff. HTMLOptionElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setDefaultSelected :: forall eff. Boolean -> HTMLOptionElement -> Eff (dom :: DOM | eff) Unit
+foreign import defaultSelected :: HTMLOptionElement -> Effect Boolean
+foreign import setDefaultSelected :: Boolean -> HTMLOptionElement -> Effect Unit
 
-foreign import selected :: forall eff. HTMLOptionElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setSelected :: forall eff. Boolean -> HTMLOptionElement -> Eff (dom :: DOM | eff) Unit
+foreign import selected :: HTMLOptionElement -> Effect Boolean
+foreign import setSelected :: Boolean -> HTMLOptionElement -> Effect Unit
 
-foreign import value :: forall eff. HTMLOptionElement -> Eff (dom :: DOM | eff) String
-foreign import setValue :: forall eff. String -> HTMLOptionElement -> Eff (dom :: DOM | eff) Unit
+foreign import value :: HTMLOptionElement -> Effect String
+foreign import setValue :: String -> HTMLOptionElement -> Effect Unit
 
-foreign import text :: forall eff. HTMLOptionElement -> Eff (dom :: DOM | eff) String
-foreign import setText :: forall eff. String -> HTMLOptionElement -> Eff (dom :: DOM | eff) Unit
+foreign import text :: HTMLOptionElement -> Effect String
+foreign import setText :: String -> HTMLOptionElement -> Effect Unit
 
-foreign import index :: forall eff. HTMLOptionElement -> Eff (dom :: DOM | eff) Int
+foreign import index :: HTMLOptionElement -> Effect Int

--- a/src/DOM/HTML/HTMLOutputElement.purs
+++ b/src/DOM/HTML/HTMLOutputElement.purs
@@ -17,41 +17,40 @@ module DOM.HTML.HTMLOutputElement
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 
-import DOM (DOM)
 import DOM.Node.Types (NodeList)
 import DOM.HTML.Types (HTMLOutputElement, HTMLFormElement, ValidityState)
 
 --   [PutForwards=value] readonly attribute DOMSettableTokenList htmlFor;
 
-form :: forall eff. HTMLOutputElement -> Eff (dom :: DOM | eff) (Maybe HTMLFormElement)
+form :: HTMLOutputElement -> Effect (Maybe HTMLFormElement)
 form = map toMaybe <<< _form
 
-foreign import _form :: forall eff. HTMLOutputElement -> Eff (dom :: DOM | eff) (Nullable HTMLFormElement)
+foreign import _form :: HTMLOutputElement -> Effect (Nullable HTMLFormElement)
 
-foreign import name :: forall eff. HTMLOutputElement -> Eff (dom :: DOM | eff) String
-foreign import setName :: forall eff. String -> HTMLOutputElement -> Eff (dom :: DOM | eff) Unit
+foreign import name :: HTMLOutputElement -> Effect String
+foreign import setName :: String -> HTMLOutputElement -> Effect Unit
 
-foreign import type_ :: forall eff. HTMLOutputElement -> Eff (dom :: DOM | eff) String
+foreign import type_ :: HTMLOutputElement -> Effect String
 
-foreign import defaultValue :: forall eff. HTMLOutputElement -> Eff (dom :: DOM | eff) String
-foreign import setDefaultValue :: forall eff. String -> HTMLOutputElement -> Eff (dom :: DOM | eff) Unit
+foreign import defaultValue :: HTMLOutputElement -> Effect String
+foreign import setDefaultValue :: String -> HTMLOutputElement -> Effect Unit
 
-foreign import value :: forall eff. HTMLOutputElement -> Eff (dom :: DOM | eff) String
-foreign import setValue :: forall eff. String -> HTMLOutputElement -> Eff (dom :: DOM | eff) Unit
+foreign import value :: HTMLOutputElement -> Effect String
+foreign import setValue :: String -> HTMLOutputElement -> Effect Unit
 
-foreign import willValidate :: forall eff. HTMLOutputElement -> Eff (dom :: DOM | eff) Boolean
+foreign import willValidate :: HTMLOutputElement -> Effect Boolean
 
-foreign import validity :: forall eff. HTMLOutputElement -> Eff (dom :: DOM | eff) ValidityState
+foreign import validity :: HTMLOutputElement -> Effect ValidityState
 
-foreign import validationMessage :: forall eff. HTMLOutputElement -> Eff (dom :: DOM | eff) String
+foreign import validationMessage :: HTMLOutputElement -> Effect String
 
-foreign import checkValidity :: forall eff. HTMLOutputElement -> Eff (dom :: DOM | eff) Boolean
+foreign import checkValidity :: HTMLOutputElement -> Effect Boolean
 
-foreign import setCustomValidity :: forall eff. String -> HTMLOutputElement -> Eff (dom :: DOM | eff) Unit
+foreign import setCustomValidity :: String -> HTMLOutputElement -> Effect Unit
 
-foreign import labels :: forall eff. HTMLOutputElement -> Eff (dom :: DOM | eff) NodeList
+foreign import labels :: HTMLOutputElement -> Effect NodeList

--- a/src/DOM/HTML/HTMLParamElement.purs
+++ b/src/DOM/HTML/HTMLParamElement.purs
@@ -2,13 +2,12 @@ module DOM.HTML.HTMLParamElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLParamElement)
 
-foreign import name :: forall eff. HTMLParamElement -> Eff (dom :: DOM | eff) String
-foreign import setName :: forall eff. String -> HTMLParamElement -> Eff (dom :: DOM | eff) Unit
+foreign import name :: HTMLParamElement -> Effect String
+foreign import setName :: String -> HTMLParamElement -> Effect Unit
 
-foreign import value :: forall eff. HTMLParamElement -> Eff (dom :: DOM | eff) String
-foreign import setValue :: forall eff. String -> HTMLParamElement -> Eff (dom :: DOM | eff) Unit
+foreign import value :: HTMLParamElement -> Effect String
+foreign import setValue :: String -> HTMLParamElement -> Effect Unit

--- a/src/DOM/HTML/HTMLProgressElement.purs
+++ b/src/DOM/HTML/HTMLProgressElement.purs
@@ -2,18 +2,17 @@ module DOM.HTML.HTMLProgressElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLProgressElement)
 import DOM.Node.Types (NodeList)
 
-foreign import value :: forall eff. HTMLProgressElement -> Eff (dom :: DOM | eff) Number
-foreign import setValue :: forall eff. Number -> HTMLProgressElement -> Eff (dom :: DOM | eff) Unit
+foreign import value :: HTMLProgressElement -> Effect Number
+foreign import setValue :: Number -> HTMLProgressElement -> Effect Unit
 
-foreign import max :: forall eff. HTMLProgressElement -> Eff (dom :: DOM | eff) Number
-foreign import setMax :: forall eff. Number -> HTMLProgressElement -> Eff (dom :: DOM | eff) Unit
+foreign import max :: HTMLProgressElement -> Effect Number
+foreign import setMax :: Number -> HTMLProgressElement -> Effect Unit
 
-foreign import position :: forall eff. HTMLProgressElement -> Eff (dom :: DOM | eff) Number
+foreign import position :: HTMLProgressElement -> Effect Number
 
-foreign import labels :: forall eff. HTMLProgressElement -> Eff (dom :: DOM | eff) NodeList
+foreign import labels :: HTMLProgressElement -> Effect NodeList

--- a/src/DOM/HTML/HTMLQuoteElement.purs
+++ b/src/DOM/HTML/HTMLQuoteElement.purs
@@ -2,10 +2,9 @@ module DOM.HTML.HTMLQuoteElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLQuoteElement)
 
-foreign import cite :: forall eff. HTMLQuoteElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setCite :: forall eff. Boolean -> HTMLQuoteElement -> Eff (dom :: DOM | eff) Unit
+foreign import cite :: HTMLQuoteElement -> Effect Boolean
+foreign import setCite :: Boolean -> HTMLQuoteElement -> Effect Unit

--- a/src/DOM/HTML/HTMLScriptElement.purs
+++ b/src/DOM/HTML/HTMLScriptElement.purs
@@ -2,28 +2,27 @@ module DOM.HTML.HTMLScriptElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLScriptElement)
 
-foreign import src :: forall eff. HTMLScriptElement -> Eff (dom :: DOM | eff) String
-foreign import setSrc :: forall eff. String -> HTMLScriptElement -> Eff (dom :: DOM | eff) Unit
+foreign import src :: HTMLScriptElement -> Effect String
+foreign import setSrc :: String -> HTMLScriptElement -> Effect Unit
 
-foreign import type_ :: forall eff. HTMLScriptElement -> Eff (dom :: DOM | eff) String
-foreign import setType :: forall eff. String -> HTMLScriptElement -> Eff (dom :: DOM | eff) Unit
+foreign import type_ :: HTMLScriptElement -> Effect String
+foreign import setType :: String -> HTMLScriptElement -> Effect Unit
 
-foreign import charset :: forall eff. HTMLScriptElement -> Eff (dom :: DOM | eff) String
-foreign import setCharset :: forall eff. String -> HTMLScriptElement -> Eff (dom :: DOM | eff) Unit
+foreign import charset :: HTMLScriptElement -> Effect String
+foreign import setCharset :: String -> HTMLScriptElement -> Effect Unit
 
-foreign import async :: forall eff. HTMLScriptElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setAsync :: forall eff. Boolean -> HTMLScriptElement -> Eff (dom :: DOM | eff) Unit
+foreign import async :: HTMLScriptElement -> Effect Boolean
+foreign import setAsync :: Boolean -> HTMLScriptElement -> Effect Unit
 
-foreign import defer :: forall eff. HTMLScriptElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setDefer :: forall eff. Boolean -> HTMLScriptElement -> Eff (dom :: DOM | eff) Unit
+foreign import defer :: HTMLScriptElement -> Effect Boolean
+foreign import setDefer :: Boolean -> HTMLScriptElement -> Effect Unit
 
-foreign import crossOrigin :: forall eff. HTMLScriptElement -> Eff (dom :: DOM | eff) String
-foreign import setCrossOrigin :: forall eff. String -> HTMLScriptElement -> Eff (dom :: DOM | eff) Unit
+foreign import crossOrigin :: HTMLScriptElement -> Effect String
+foreign import setCrossOrigin :: String -> HTMLScriptElement -> Effect Unit
 
-foreign import text :: forall eff. HTMLScriptElement -> Eff (dom :: DOM | eff) String
-foreign import setText :: forall eff. String -> HTMLScriptElement -> Eff (dom :: DOM | eff) Unit
+foreign import text :: HTMLScriptElement -> Effect String
+foreign import setText :: String -> HTMLScriptElement -> Effect Unit

--- a/src/DOM/HTML/HTMLSelectElement.purs
+++ b/src/DOM/HTML/HTMLSelectElement.purs
@@ -30,44 +30,43 @@ module DOM.HTML.HTMLSelectElement
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLSelectElement, HTMLFormElement, ValidityState)
 import DOM.Node.Types (NodeList, HTMLCollection)
 
-foreign import autofocus :: forall eff. HTMLSelectElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setAutofocus :: forall eff. Boolean -> HTMLSelectElement -> Eff (dom :: DOM | eff) Unit
+foreign import autofocus :: HTMLSelectElement -> Effect Boolean
+foreign import setAutofocus :: Boolean -> HTMLSelectElement -> Effect Unit
 
-foreign import disabled :: forall eff. HTMLSelectElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setDisabled :: forall eff. Boolean -> HTMLSelectElement -> Eff (dom :: DOM | eff) Unit
+foreign import disabled :: HTMLSelectElement -> Effect Boolean
+foreign import setDisabled :: Boolean -> HTMLSelectElement -> Effect Unit
 
-form :: forall eff. HTMLSelectElement -> Eff (dom :: DOM | eff) (Maybe HTMLFormElement)
+form :: HTMLSelectElement -> Effect (Maybe HTMLFormElement)
 form = map toMaybe <<< _form
 
-foreign import _form :: forall eff. HTMLSelectElement -> Eff (dom :: DOM | eff) (Nullable HTMLFormElement)
+foreign import _form :: HTMLSelectElement -> Effect (Nullable HTMLFormElement)
 
-foreign import multiple :: forall eff. HTMLSelectElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setMultiple :: forall eff. Boolean -> HTMLSelectElement -> Eff (dom :: DOM | eff) Unit
+foreign import multiple :: HTMLSelectElement -> Effect Boolean
+foreign import setMultiple :: Boolean -> HTMLSelectElement -> Effect Unit
 
-foreign import name :: forall eff. HTMLSelectElement -> Eff (dom :: DOM | eff) String
-foreign import setName :: forall eff. String -> HTMLSelectElement -> Eff (dom :: DOM | eff) Unit
+foreign import name :: HTMLSelectElement -> Effect String
+foreign import setName :: String -> HTMLSelectElement -> Effect Unit
 
-foreign import required :: forall eff. HTMLSelectElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setRequired :: forall eff. Boolean -> HTMLSelectElement -> Eff (dom :: DOM | eff) Unit
+foreign import required :: HTMLSelectElement -> Effect Boolean
+foreign import setRequired :: Boolean -> HTMLSelectElement -> Effect Unit
 
-foreign import size :: forall eff. HTMLSelectElement -> Eff (dom :: DOM | eff) Int
-foreign import setSize :: forall eff. Int -> HTMLSelectElement -> Eff (dom :: DOM | eff) Unit
+foreign import size :: HTMLSelectElement -> Effect Int
+foreign import setSize :: Int -> HTMLSelectElement -> Effect Unit
 
-foreign import type_ :: forall eff. HTMLSelectElement -> Eff (dom :: DOM | eff) String
+foreign import type_ :: HTMLSelectElement -> Effect String
 
 --   readonly attribute HTMLOptionsCollection options;
 
-foreign import length :: forall eff. HTMLSelectElement -> Eff (dom :: DOM | eff) Int
-foreign import setLength :: forall eff. Int -> HTMLSelectElement -> Eff (dom :: DOM | eff) Unit
+foreign import length :: HTMLSelectElement -> Effect Int
+foreign import setLength :: Int -> HTMLSelectElement -> Effect Unit
 
 --   getter Element? item(unsigned long index);
 --   HTMLOptionElement? namedItem(DOMString name);
@@ -76,22 +75,22 @@ foreign import setLength :: forall eff. Int -> HTMLSelectElement -> Eff (dom :: 
 --   void remove(long index);
 --   setter creator void (unsigned long index, HTMLOptionElement? option);
 
-foreign import selectedOptions :: forall eff. HTMLSelectElement -> Eff (dom :: DOM | eff) HTMLCollection
+foreign import selectedOptions :: HTMLSelectElement -> Effect HTMLCollection
 
-foreign import selectedIndex :: forall eff. HTMLSelectElement -> Eff (dom :: DOM | eff) Int
-foreign import setSelectedIndex :: forall eff. Int -> HTMLSelectElement -> Eff (dom :: DOM | eff) Unit
+foreign import selectedIndex :: HTMLSelectElement -> Effect Int
+foreign import setSelectedIndex :: Int -> HTMLSelectElement -> Effect Unit
 
-foreign import value :: forall eff. HTMLSelectElement -> Eff (dom :: DOM | eff) String
-foreign import setValue :: forall eff. String -> HTMLSelectElement -> Eff (dom :: DOM | eff) Unit
+foreign import value :: HTMLSelectElement -> Effect String
+foreign import setValue :: String -> HTMLSelectElement -> Effect Unit
 
-foreign import willValidate :: forall eff. HTMLSelectElement -> Eff (dom :: DOM | eff) Boolean
+foreign import willValidate :: HTMLSelectElement -> Effect Boolean
 
-foreign import validity :: forall eff. HTMLSelectElement -> Eff (dom :: DOM | eff) ValidityState
+foreign import validity :: HTMLSelectElement -> Effect ValidityState
 
-foreign import validationMessage :: forall eff. HTMLSelectElement -> Eff (dom :: DOM | eff) String
+foreign import validationMessage :: HTMLSelectElement -> Effect String
 
-foreign import checkValidity :: forall eff. HTMLSelectElement -> Eff (dom :: DOM | eff) Boolean
+foreign import checkValidity :: HTMLSelectElement -> Effect Boolean
 
-foreign import setCustomValidity :: forall eff. String -> HTMLSelectElement -> Eff (dom :: DOM | eff) Unit
+foreign import setCustomValidity :: String -> HTMLSelectElement -> Effect Unit
 
-foreign import labels :: forall eff. HTMLSelectElement -> Eff (dom :: DOM | eff) NodeList
+foreign import labels :: HTMLSelectElement -> Effect NodeList

--- a/src/DOM/HTML/HTMLSourceElement.purs
+++ b/src/DOM/HTML/HTMLSourceElement.purs
@@ -2,19 +2,18 @@ module DOM.HTML.HTMLSourceElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLSourceElement)
 
 -- [NamedConstructor=Audio(optional DOMString src)]
 
-foreign import src :: forall eff. HTMLSourceElement -> Eff (dom :: DOM | eff) String
-foreign import setSrc :: forall eff. String -> HTMLSourceElement -> Eff (dom :: DOM | eff) Unit
+foreign import src :: HTMLSourceElement -> Effect String
+foreign import setSrc :: String -> HTMLSourceElement -> Effect Unit
 
-foreign import type_ :: forall eff. HTMLSourceElement -> Eff (dom :: DOM | eff) String
-foreign import setType :: forall eff. String -> HTMLSourceElement -> Eff (dom :: DOM | eff) Unit
+foreign import type_ :: HTMLSourceElement -> Effect String
+foreign import setType :: String -> HTMLSourceElement -> Effect Unit
 
-foreign import media :: forall eff. HTMLSourceElement -> Eff (dom :: DOM | eff) String
-foreign import setMedia :: forall eff. String -> HTMLSourceElement -> Eff (dom :: DOM | eff) Unit
+foreign import media :: HTMLSourceElement -> Effect String
+foreign import setMedia :: String -> HTMLSourceElement -> Effect Unit
 

--- a/src/DOM/HTML/HTMLStyleElement.purs
+++ b/src/DOM/HTML/HTMLStyleElement.purs
@@ -2,16 +2,15 @@ module DOM.HTML.HTMLStyleElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLStyleElement)
 
-foreign import disabled :: forall eff. HTMLStyleElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setDisabled :: forall eff. Boolean -> HTMLStyleElement -> Eff (dom :: DOM | eff) Unit
+foreign import disabled :: HTMLStyleElement -> Effect Boolean
+foreign import setDisabled :: Boolean -> HTMLStyleElement -> Effect Unit
 
-foreign import media :: forall eff. HTMLStyleElement -> Eff (dom :: DOM | eff) String
-foreign import setMedia :: forall eff. String -> HTMLStyleElement -> Eff (dom :: DOM | eff) Unit
+foreign import media :: HTMLStyleElement -> Effect String
+foreign import setMedia :: String -> HTMLStyleElement -> Effect Unit
 
-foreign import type_ :: forall eff. HTMLStyleElement -> Eff (dom :: DOM | eff) String
-foreign import setType :: forall eff. String -> HTMLStyleElement -> Eff (dom :: DOM | eff) Unit
+foreign import type_ :: HTMLStyleElement -> Effect String
+foreign import setType :: String -> HTMLStyleElement -> Effect Unit

--- a/src/DOM/HTML/HTMLTableCellElement.purs
+++ b/src/DOM/HTML/HTMLTableCellElement.purs
@@ -2,17 +2,16 @@ module DOM.HTML.HTMLTableCellElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLTableCellElement)
 
-foreign import colSpan :: forall eff. HTMLTableCellElement -> Eff (dom :: DOM | eff) Int
-foreign import setColSpan :: forall eff. Int -> HTMLTableCellElement -> Eff (dom :: DOM | eff) Unit
+foreign import colSpan :: HTMLTableCellElement -> Effect Int
+foreign import setColSpan :: Int -> HTMLTableCellElement -> Effect Unit
 
-foreign import rowSpan :: forall eff. HTMLTableCellElement -> Eff (dom :: DOM | eff) Int
-foreign import setRowSpan :: forall eff. Int -> HTMLTableCellElement -> Eff (dom :: DOM | eff) Unit
+foreign import rowSpan :: HTMLTableCellElement -> Effect Int
+foreign import setRowSpan :: Int -> HTMLTableCellElement -> Effect Unit
 
 --   [PutForwards=value] readonly attribute DOMSettableTokenList headers;
 
-foreign import cellIndex :: forall eff. HTMLTableCellElement -> Eff (dom :: DOM | eff) Int
+foreign import cellIndex :: HTMLTableCellElement -> Effect Int

--- a/src/DOM/HTML/HTMLTableColElement.purs
+++ b/src/DOM/HTML/HTMLTableColElement.purs
@@ -2,10 +2,9 @@ module DOM.HTML.HTMLTableColElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLTableColElement)
 
-foreign import span :: forall eff. HTMLTableColElement -> Eff (dom :: DOM | eff) Int
-foreign import setSpan :: forall eff. Int -> HTMLTableColElement -> Eff (dom :: DOM | eff) Unit
+foreign import span :: HTMLTableColElement -> Effect Int
+foreign import setSpan :: Int -> HTMLTableColElement -> Effect Unit

--- a/src/DOM/HTML/HTMLTableElement.purs
+++ b/src/DOM/HTML/HTMLTableElement.purs
@@ -23,62 +23,61 @@ module DOM.HTML.HTMLTableElement
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe, toNullable)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLTableElement, HTMLTableCaptionElement, HTMLElement, HTMLTableSectionElement)
 import DOM.Node.Types (HTMLCollection)
 
-caption :: forall eff. HTMLTableElement -> Eff (dom :: DOM | eff) (Maybe HTMLTableCaptionElement)
+caption :: HTMLTableElement -> Effect (Maybe HTMLTableCaptionElement)
 caption = map toMaybe <<< _caption
 
-setCaption :: forall eff. Maybe HTMLTableCaptionElement -> HTMLTableElement -> Eff (dom :: DOM | eff) Unit
+setCaption :: Maybe HTMLTableCaptionElement -> HTMLTableElement -> Effect Unit
 setCaption = _setCaption <<< toNullable
 
-foreign import _caption :: forall eff. HTMLTableElement -> Eff (dom :: DOM | eff) (Nullable HTMLTableCaptionElement)
-foreign import _setCaption :: forall eff. Nullable HTMLTableCaptionElement -> HTMLTableElement -> Eff (dom :: DOM | eff) Unit
+foreign import _caption :: HTMLTableElement -> Effect (Nullable HTMLTableCaptionElement)
+foreign import _setCaption :: Nullable HTMLTableCaptionElement -> HTMLTableElement -> Effect Unit
 
-foreign import createCaption :: forall eff. HTMLTableElement -> Eff (dom :: DOM | eff) HTMLElement
-foreign import deleteCaption :: forall eff. HTMLTableElement -> Eff (dom :: DOM | eff) Unit
+foreign import createCaption :: HTMLTableElement -> Effect HTMLElement
+foreign import deleteCaption :: HTMLTableElement -> Effect Unit
 
-tHead :: forall eff. HTMLTableElement -> Eff (dom :: DOM | eff) (Maybe HTMLTableSectionElement)
+tHead :: HTMLTableElement -> Effect (Maybe HTMLTableSectionElement)
 tHead = map toMaybe <<< _tHead
 
-setTHead :: forall eff. Maybe HTMLTableSectionElement -> HTMLTableElement -> Eff (dom :: DOM | eff) Unit
+setTHead :: Maybe HTMLTableSectionElement -> HTMLTableElement -> Effect Unit
 setTHead = _setTHead <<< toNullable
 
-foreign import _tHead :: forall eff. HTMLTableElement -> Eff (dom :: DOM | eff) (Nullable HTMLTableSectionElement)
-foreign import _setTHead :: forall eff. Nullable HTMLTableSectionElement -> HTMLTableElement -> Eff (dom :: DOM | eff) Unit
+foreign import _tHead :: HTMLTableElement -> Effect (Nullable HTMLTableSectionElement)
+foreign import _setTHead :: Nullable HTMLTableSectionElement -> HTMLTableElement -> Effect Unit
 
-foreign import createTHead :: forall eff. HTMLTableElement -> Eff (dom :: DOM | eff) HTMLElement
-foreign import deleteTHead :: forall eff. HTMLTableElement -> Eff (dom :: DOM | eff) Unit
+foreign import createTHead :: HTMLTableElement -> Effect HTMLElement
+foreign import deleteTHead :: HTMLTableElement -> Effect Unit
 
-tFoot :: forall eff. HTMLTableElement -> Eff (dom :: DOM | eff) (Maybe HTMLTableSectionElement)
+tFoot :: HTMLTableElement -> Effect (Maybe HTMLTableSectionElement)
 tFoot = map toMaybe <<< _tFoot
 
-setTFoot :: forall eff. Maybe HTMLTableSectionElement -> HTMLTableElement -> Eff (dom :: DOM | eff) Unit
+setTFoot :: Maybe HTMLTableSectionElement -> HTMLTableElement -> Effect Unit
 setTFoot = _setTFoot <<< toNullable
 
-foreign import _tFoot :: forall eff. HTMLTableElement -> Eff (dom :: DOM | eff) (Nullable HTMLTableSectionElement)
-foreign import _setTFoot :: forall eff. Nullable HTMLTableSectionElement -> HTMLTableElement -> Eff (dom :: DOM | eff) Unit
+foreign import _tFoot :: HTMLTableElement -> Effect (Nullable HTMLTableSectionElement)
+foreign import _setTFoot :: Nullable HTMLTableSectionElement -> HTMLTableElement -> Effect Unit
 
-foreign import createTFoot :: forall eff. HTMLTableElement -> Eff (dom :: DOM | eff) HTMLElement
-foreign import deleteTFoot :: forall eff. HTMLTableElement -> Eff (dom :: DOM | eff) Unit
+foreign import createTFoot :: HTMLTableElement -> Effect HTMLElement
+foreign import deleteTFoot :: HTMLTableElement -> Effect Unit
 
-foreign import tBodies :: forall eff. HTMLTableElement -> Eff (dom :: DOM | eff) HTMLCollection
-foreign import createTBody :: forall eff. HTMLTableElement -> Eff (dom :: DOM | eff) HTMLElement
+foreign import tBodies :: HTMLTableElement -> Effect HTMLCollection
+foreign import createTBody :: HTMLTableElement -> Effect HTMLElement
 
-foreign import rows :: forall eff. HTMLTableElement -> Eff (dom :: DOM | eff) HTMLCollection
+foreign import rows :: HTMLTableElement -> Effect HTMLCollection
 
-insertRow :: forall eff. HTMLTableElement -> Eff (dom :: DOM | eff) HTMLElement
+insertRow :: HTMLTableElement -> Effect HTMLElement
 insertRow = insertRow' (-1)
 
-foreign import insertRow' :: forall eff. Int -> HTMLTableElement -> Eff (dom :: DOM | eff) HTMLElement
+foreign import insertRow' :: Int -> HTMLTableElement -> Effect HTMLElement
 
-foreign import deleteRow :: forall eff. Int -> HTMLTableElement -> Eff (dom :: DOM | eff) Unit
+foreign import deleteRow :: Int -> HTMLTableElement -> Effect Unit
 
-foreign import border :: forall eff. HTMLTableElement -> Eff (dom :: DOM | eff) String
-foreign import setBorder :: forall eff. String -> HTMLTableElement -> Eff (dom :: DOM | eff) Unit
+foreign import border :: HTMLTableElement -> Effect String
+foreign import setBorder :: String -> HTMLTableElement -> Effect Unit

--- a/src/DOM/HTML/HTMLTableHeaderCellElement.purs
+++ b/src/DOM/HTML/HTMLTableHeaderCellElement.purs
@@ -2,13 +2,12 @@ module DOM.HTML.HTMLTableHeaderCellElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLTableHeaderCellElement)
 
-foreign import scope :: forall eff. HTMLTableHeaderCellElement -> Eff (dom :: DOM | eff) String
-foreign import setScope :: forall eff. String -> HTMLTableHeaderCellElement -> Eff (dom :: DOM | eff) Unit
+foreign import scope :: HTMLTableHeaderCellElement -> Effect String
+foreign import setScope :: String -> HTMLTableHeaderCellElement -> Effect Unit
 
-foreign import abbr :: forall eff. HTMLTableHeaderCellElement -> Eff (dom :: DOM | eff) String
-foreign import setAbbr :: forall eff. String -> HTMLTableHeaderCellElement -> Eff (dom :: DOM | eff) Unit
+foreign import abbr :: HTMLTableHeaderCellElement -> Effect String
+foreign import setAbbr :: String -> HTMLTableHeaderCellElement -> Effect Unit

--- a/src/DOM/HTML/HTMLTableRowElement.purs
+++ b/src/DOM/HTML/HTMLTableRowElement.purs
@@ -2,21 +2,20 @@ module DOM.HTML.HTMLTableRowElement where
 
 import Prelude (Unit, negate)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLTableRowElement, HTMLElement)
 import DOM.Node.Types (HTMLCollection)
 
-foreign import rowIndex :: forall eff. HTMLTableRowElement -> Eff (dom :: DOM | eff) Int
+foreign import rowIndex :: HTMLTableRowElement -> Effect Int
 
-foreign import sectionRowIndex :: forall eff. HTMLTableRowElement -> Eff (dom :: DOM | eff) Int
+foreign import sectionRowIndex :: HTMLTableRowElement -> Effect Int
 
-foreign import cells :: forall eff. HTMLTableRowElement -> Eff (dom :: DOM | eff) HTMLCollection
+foreign import cells :: HTMLTableRowElement -> Effect HTMLCollection
 
-insertCell :: forall eff. HTMLTableRowElement -> Eff (dom :: DOM | eff) HTMLElement
+insertCell :: HTMLTableRowElement -> Effect HTMLElement
 insertCell = insertCell' (-1)
 
-foreign import insertCell' :: forall eff. Int -> HTMLTableRowElement -> Eff (dom :: DOM | eff) HTMLElement
+foreign import insertCell' :: Int -> HTMLTableRowElement -> Effect HTMLElement
 
-foreign import deleteCell :: forall eff. Int -> HTMLTableRowElement -> Eff (dom :: DOM | eff) Unit
+foreign import deleteCell :: Int -> HTMLTableRowElement -> Effect Unit

--- a/src/DOM/HTML/HTMLTableSectionElement.purs
+++ b/src/DOM/HTML/HTMLTableSectionElement.purs
@@ -2,17 +2,16 @@ module DOM.HTML.HTMLTableSectionElement where
 
 import Prelude (Unit, negate)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLTableSectionElement, HTMLElement)
 import DOM.Node.Types (HTMLCollection)
 
-foreign import rows :: forall eff. HTMLTableSectionElement -> Eff (dom :: DOM | eff) HTMLCollection
+foreign import rows :: HTMLTableSectionElement -> Effect HTMLCollection
 
-insertRow :: forall eff. HTMLTableSectionElement -> Eff (dom :: DOM | eff) HTMLElement
+insertRow :: HTMLTableSectionElement -> Effect HTMLElement
 insertRow = insertRow' (-1)
 
-foreign import insertRow' :: forall eff. Int -> HTMLTableSectionElement -> Eff (dom :: DOM | eff) HTMLElement
+foreign import insertRow' :: Int -> HTMLTableSectionElement -> Effect HTMLElement
 
-foreign import deleteRow :: forall eff. Int -> HTMLTableSectionElement -> Eff (dom :: DOM | eff) Unit
+foreign import deleteRow :: Int -> HTMLTableSectionElement -> Effect Unit

--- a/src/DOM/HTML/HTMLTemplateElement.purs
+++ b/src/DOM/HTML/HTMLTemplateElement.purs
@@ -1,9 +1,8 @@
 module DOM.HTML.HTMLTemplateElement where
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLTemplateElement)
 import DOM.Node.Types (DocumentFragment)
 
-foreign import content :: forall eff. HTMLTemplateElement -> Eff (dom :: DOM | eff) DocumentFragment
+foreign import content :: HTMLTemplateElement -> Effect DocumentFragment

--- a/src/DOM/HTML/HTMLTextAreaElement.purs
+++ b/src/DOM/HTML/HTMLTextAreaElement.purs
@@ -52,94 +52,93 @@ module DOM.HTML.HTMLTextAreaElement
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 
-import DOM (DOM)
 import DOM.HTML.SelectionMode (SelectionMode)
 import DOM.HTML.Types (HTMLTextAreaElement, HTMLFormElement, ValidityState)
 import DOM.Node.Types (NodeList)
 
-foreign import autocomplete :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) String
-foreign import setAutocomplete :: forall eff. String -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import autocomplete :: HTMLTextAreaElement -> Effect String
+foreign import setAutocomplete :: String -> HTMLTextAreaElement -> Effect Unit
 
-foreign import autofocus :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setAutofocus :: forall eff. Boolean -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import autofocus :: HTMLTextAreaElement -> Effect Boolean
+foreign import setAutofocus :: Boolean -> HTMLTextAreaElement -> Effect Unit
 
-foreign import cols :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) Int
-foreign import setCols :: forall eff. Int -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import cols :: HTMLTextAreaElement -> Effect Int
+foreign import setCols :: Int -> HTMLTextAreaElement -> Effect Unit
 
-foreign import dirName :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) String
-foreign import setDirName :: forall eff. String -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import dirName :: HTMLTextAreaElement -> Effect String
+foreign import setDirName :: String -> HTMLTextAreaElement -> Effect Unit
 
-foreign import disabled :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setDisabled :: forall eff. Boolean -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import disabled :: HTMLTextAreaElement -> Effect Boolean
+foreign import setDisabled :: Boolean -> HTMLTextAreaElement -> Effect Unit
 
-form :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) (Maybe HTMLFormElement)
+form :: HTMLTextAreaElement -> Effect (Maybe HTMLFormElement)
 form = map toMaybe <<< _form
 
-foreign import _form :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) (Nullable HTMLFormElement)
+foreign import _form :: HTMLTextAreaElement -> Effect (Nullable HTMLFormElement)
 
-foreign import maxLength :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) Int
-foreign import setMaxLength :: forall eff. Int -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import maxLength :: HTMLTextAreaElement -> Effect Int
+foreign import setMaxLength :: Int -> HTMLTextAreaElement -> Effect Unit
 
-foreign import minLength :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) Int
-foreign import setMinLength :: forall eff. Int -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import minLength :: HTMLTextAreaElement -> Effect Int
+foreign import setMinLength :: Int -> HTMLTextAreaElement -> Effect Unit
 
-foreign import name :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) String
-foreign import setName :: forall eff. String -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import name :: HTMLTextAreaElement -> Effect String
+foreign import setName :: String -> HTMLTextAreaElement -> Effect Unit
 
-foreign import placeholder :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) String
-foreign import setPlaceholder :: forall eff. String -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import placeholder :: HTMLTextAreaElement -> Effect String
+foreign import setPlaceholder :: String -> HTMLTextAreaElement -> Effect Unit
 
-foreign import readOnly :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setReadOnly :: forall eff. Boolean -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import readOnly :: HTMLTextAreaElement -> Effect Boolean
+foreign import setReadOnly :: Boolean -> HTMLTextAreaElement -> Effect Unit
 
-foreign import required :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setRequired :: forall eff. Boolean -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import required :: HTMLTextAreaElement -> Effect Boolean
+foreign import setRequired :: Boolean -> HTMLTextAreaElement -> Effect Unit
 
-foreign import rows :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) Int
-foreign import setRows :: forall eff. Int -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import rows :: HTMLTextAreaElement -> Effect Int
+foreign import setRows :: Int -> HTMLTextAreaElement -> Effect Unit
 
-foreign import wrap :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) String
-foreign import setWrap :: forall eff. String -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import wrap :: HTMLTextAreaElement -> Effect String
+foreign import setWrap :: String -> HTMLTextAreaElement -> Effect Unit
 
-foreign import type_ :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) String
+foreign import type_ :: HTMLTextAreaElement -> Effect String
 
-foreign import defaultValue :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) String
-foreign import setDefaultValue :: forall eff. String -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import defaultValue :: HTMLTextAreaElement -> Effect String
+foreign import setDefaultValue :: String -> HTMLTextAreaElement -> Effect Unit
 
-foreign import value :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) String
-foreign import setValue :: forall eff. String -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import value :: HTMLTextAreaElement -> Effect String
+foreign import setValue :: String -> HTMLTextAreaElement -> Effect Unit
 
-foreign import textLength :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) Int
+foreign import textLength :: HTMLTextAreaElement -> Effect Int
 
-foreign import willValidate :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) Boolean
+foreign import willValidate :: HTMLTextAreaElement -> Effect Boolean
 
-foreign import validity :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) ValidityState
+foreign import validity :: HTMLTextAreaElement -> Effect ValidityState
 
-foreign import validationMessage :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) String
+foreign import validationMessage :: HTMLTextAreaElement -> Effect String
 
-foreign import checkValidity :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) Boolean
+foreign import checkValidity :: HTMLTextAreaElement -> Effect Boolean
 
-foreign import setCustomValidity :: forall eff. String -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import setCustomValidity :: String -> HTMLTextAreaElement -> Effect Unit
 
-foreign import labels :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) NodeList
+foreign import labels :: HTMLTextAreaElement -> Effect NodeList
 
-foreign import select :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import select :: HTMLTextAreaElement -> Effect Unit
 
-foreign import selectionStart :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) Int
-foreign import setSelectionStart :: forall eff. Int -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import selectionStart :: HTMLTextAreaElement -> Effect Int
+foreign import setSelectionStart :: Int -> HTMLTextAreaElement -> Effect Unit
 
-foreign import selectionEnd :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) Int
-foreign import setSelectionEnd :: forall eff. Int -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import selectionEnd :: HTMLTextAreaElement -> Effect Int
+foreign import setSelectionEnd :: Int -> HTMLTextAreaElement -> Effect Unit
 
-foreign import selectionDirection :: forall eff. HTMLTextAreaElement -> Eff (dom :: DOM | eff) String
-foreign import setSelectionDirection :: forall eff. String -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import selectionDirection :: HTMLTextAreaElement -> Effect String
+foreign import setSelectionDirection :: String -> HTMLTextAreaElement -> Effect Unit
 
-foreign import setRangeText :: forall eff. String -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
-foreign import setRangeText' :: forall eff. String -> Int -> Int -> SelectionMode -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import setRangeText :: String -> HTMLTextAreaElement -> Effect Unit
+foreign import setRangeText' :: String -> Int -> Int -> SelectionMode -> HTMLTextAreaElement -> Effect Unit
 
-foreign import setSelectionRange :: forall eff. Int -> Int -> String -> HTMLTextAreaElement -> Eff (dom :: DOM | eff) Unit
+foreign import setSelectionRange :: Int -> Int -> String -> HTMLTextAreaElement -> Effect Unit

--- a/src/DOM/HTML/HTMLTimeElement.purs
+++ b/src/DOM/HTML/HTMLTimeElement.purs
@@ -2,10 +2,9 @@ module DOM.HTML.HTMLTimeElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLTimeElement)
 
-foreign import dateTime :: forall eff. HTMLTimeElement -> Eff (dom :: DOM | eff) String
-foreign import setDateTime :: forall eff. String -> HTMLTimeElement -> Eff (dom :: DOM | eff) Unit
+foreign import dateTime :: HTMLTimeElement -> Effect String
+foreign import setDateTime :: String -> HTMLTimeElement -> Effect Unit

--- a/src/DOM/HTML/HTMLTitleElement.purs
+++ b/src/DOM/HTML/HTMLTitleElement.purs
@@ -2,10 +2,9 @@ module DOM.HTML.HTMLTitleElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLTitleElement)
 
-foreign import text :: forall eff. HTMLTitleElement -> Eff (dom :: DOM | eff) String
-foreign import setText :: forall eff. String -> HTMLTitleElement -> Eff (dom :: DOM | eff) Unit
+foreign import text :: HTMLTitleElement -> Effect String
+foreign import setText :: String -> HTMLTitleElement -> Effect Unit

--- a/src/DOM/HTML/HTMLTrackElement.purs
+++ b/src/DOM/HTML/HTMLTrackElement.purs
@@ -2,45 +2,32 @@ module DOM.HTML.HTMLTrackElement where
 
 import Prelude (Unit, (<<<), map)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
 import Data.Enum (toEnum)
 import Data.Maybe (fromJust)
 
-import DOM (DOM)
 import DOM.HTML.HTMLTrackElement.ReadyState (ReadyState)
 import DOM.HTML.Types (HTMLTrackElement)
 
-foreign import kind :: forall eff.
-  HTMLTrackElement -> Eff (dom :: DOM | eff) String
-foreign import setKind :: forall eff.
-  String -> HTMLTrackElement -> Eff (dom :: DOM | eff) Unit
+foreign import kind :: HTMLTrackElement -> Effect String
+foreign import setKind :: String -> HTMLTrackElement -> Effect Unit
 
-foreign import src :: forall eff.
-  HTMLTrackElement -> Eff (dom :: DOM | eff) String
-foreign import setSrc :: forall eff.
-  String -> HTMLTrackElement -> Eff (dom :: DOM | eff) Unit
+foreign import src :: HTMLTrackElement -> Effect String
+foreign import setSrc :: String -> HTMLTrackElement -> Effect Unit
 
-foreign import srclang :: forall eff.
-  HTMLTrackElement -> Eff (dom :: DOM | eff) String
-foreign import setSrclang :: forall eff.
-  String -> HTMLTrackElement -> Eff (dom :: DOM | eff) Unit
+foreign import srclang :: HTMLTrackElement -> Effect String
+foreign import setSrclang :: String -> HTMLTrackElement -> Effect Unit
 
-foreign import label :: forall eff.
-  HTMLTrackElement -> Eff (dom :: DOM | eff) String
-foreign import setLabel :: forall eff.
-  String -> HTMLTrackElement -> Eff (dom :: DOM | eff) Unit
+foreign import label :: HTMLTrackElement -> Effect String
+foreign import setLabel :: String -> HTMLTrackElement -> Effect Unit
 
-foreign import default :: forall eff.
-  HTMLTrackElement -> Eff (dom :: DOM | eff) Boolean
-foreign import setDefault :: forall eff.
-  Boolean -> HTMLTrackElement -> Eff (dom :: DOM | eff) Unit
+foreign import default :: HTMLTrackElement -> Effect Boolean
+foreign import setDefault :: Boolean -> HTMLTrackElement -> Effect Unit
 
-readyState :: forall eff.
-  Partial =>
-  HTMLTrackElement -> Eff (dom :: DOM | eff) ReadyState
+readyState :: Partial => HTMLTrackElement -> Effect ReadyState
 readyState = map (fromJust <<< toEnum) <<< readyStateIndex
 
-foreign import readyStateIndex :: forall eff. HTMLTrackElement -> Eff (dom :: DOM | eff) Int
+foreign import readyStateIndex :: HTMLTrackElement -> Effect Int
 
 --   readonly attribute TextTrack track;

--- a/src/DOM/HTML/HTMLVideoElement.purs
+++ b/src/DOM/HTML/HTMLVideoElement.purs
@@ -2,19 +2,18 @@ module DOM.HTML.HTMLVideoElement where
 
 import Prelude (Unit)
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.HTML.Types (HTMLVideoElement)
 
-foreign import width :: forall eff. HTMLVideoElement -> Eff (dom :: DOM | eff) Int
-foreign import setWidth :: forall eff. Int -> HTMLVideoElement -> Eff (dom :: DOM | eff) Unit
+foreign import width :: HTMLVideoElement -> Effect Int
+foreign import setWidth :: Int -> HTMLVideoElement -> Effect Unit
 
-foreign import height :: forall eff. HTMLVideoElement -> Eff (dom :: DOM | eff) Int
-foreign import setHeight :: forall eff. Int -> HTMLVideoElement -> Eff (dom :: DOM | eff) Unit
+foreign import height :: HTMLVideoElement -> Effect Int
+foreign import setHeight :: Int -> HTMLVideoElement -> Effect Unit
 
-foreign import videoWidth :: forall eff. HTMLVideoElement -> Eff (dom :: DOM | eff) Int
-foreign import videoHeight :: forall eff. HTMLVideoElement -> Eff (dom :: DOM | eff) Int
+foreign import videoWidth :: HTMLVideoElement -> Effect Int
+foreign import videoHeight :: HTMLVideoElement -> Effect Int
 
-foreign import poster :: forall eff. HTMLVideoElement -> Eff (dom :: DOM | eff) String
-foreign import setPoster :: forall eff. String -> HTMLVideoElement -> Eff (dom :: DOM | eff) Unit
+foreign import poster :: HTMLVideoElement -> Effect String
+foreign import setPoster :: String -> HTMLVideoElement -> Effect Unit

--- a/src/DOM/HTML/History.purs
+++ b/src/DOM/HTML/History.purs
@@ -1,7 +1,7 @@
 module DOM.HTML.History where
 
-import Control.Monad.Eff (Eff)
-import DOM.HTML.Types (HISTORY, History)
+import Control.Monad.Effect (Effect)
+import DOM.HTML.Types (History)
 import Data.Foreign (Foreign)
 import Data.Newtype (class Newtype)
 import Prelude (class Eq, class Ord, Unit)
@@ -20,9 +20,9 @@ derive instance eqURL :: Eq URL
 derive instance ordURL :: Ord URL
 derive instance newtypeURL :: Newtype URL _
 
-foreign import back :: forall e. History -> Eff (history :: HISTORY | e) Unit
-foreign import forward :: forall e. History -> Eff (history :: HISTORY | e) Unit
-foreign import go :: forall e. Delta -> History -> Eff (history :: HISTORY | e) Unit
-foreign import pushState :: forall e. Foreign -> DocumentTitle -> URL -> History -> Eff (history :: HISTORY | e) Unit
-foreign import replaceState :: forall e. Foreign -> DocumentTitle -> URL -> History -> Eff (history :: HISTORY | e) Unit
-foreign import state :: forall e. History -> Eff (history :: HISTORY | e) Foreign
+foreign import back :: History -> Effect Unit
+foreign import forward :: History -> Effect Unit
+foreign import go :: Delta -> History -> Effect Unit
+foreign import pushState :: Foreign -> DocumentTitle -> URL -> History -> Effect Unit
+foreign import replaceState :: Foreign -> DocumentTitle -> URL -> History -> Effect Unit
+foreign import state :: History -> Effect Foreign

--- a/src/DOM/HTML/Location.purs
+++ b/src/DOM/HTML/Location.purs
@@ -24,37 +24,36 @@ module DOM.HTML.Location
   ) where
 
 import Prelude
-import Control.Monad.Eff (Eff)
-import DOM (DOM)
+import Control.Monad.Effect (Effect)
 import DOM.HTML.Types (Location)
 
-foreign import hash :: forall eff. Location -> Eff (dom :: DOM | eff) String
-foreign import setHash :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
+foreign import hash :: Location -> Effect String
+foreign import setHash :: String -> Location -> Effect Unit
 
-foreign import host :: forall eff. Location -> Eff (dom :: DOM | eff) String
-foreign import setHost :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
+foreign import host :: Location -> Effect String
+foreign import setHost :: String -> Location -> Effect Unit
 
-foreign import hostname :: forall eff. Location -> Eff (dom :: DOM | eff) String
-foreign import setHostname :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
+foreign import hostname :: Location -> Effect String
+foreign import setHostname :: String -> Location -> Effect Unit
 
-foreign import href :: forall eff. Location -> Eff (dom :: DOM | eff) String
-foreign import setHref :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
+foreign import href :: Location -> Effect String
+foreign import setHref :: String -> Location -> Effect Unit
 
-foreign import origin :: forall eff. Location -> Eff (dom :: DOM | eff) String
-foreign import setOrigin :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
+foreign import origin :: Location -> Effect String
+foreign import setOrigin :: String -> Location -> Effect Unit
 
-foreign import pathname :: forall eff. Location -> Eff (dom :: DOM | eff) String
-foreign import setPathname :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
+foreign import pathname :: Location -> Effect String
+foreign import setPathname :: String -> Location -> Effect Unit
 
-foreign import port :: forall eff. Location -> Eff (dom :: DOM | eff) String
-foreign import setPort :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
+foreign import port :: Location -> Effect String
+foreign import setPort :: String -> Location -> Effect Unit
 
-foreign import protocol :: forall eff. Location -> Eff (dom :: DOM | eff) String
-foreign import setProtocol :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
+foreign import protocol :: Location -> Effect String
+foreign import setProtocol :: String -> Location -> Effect Unit
 
-foreign import search :: forall eff. Location -> Eff (dom :: DOM | eff) String
-foreign import setSearch :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
+foreign import search :: Location -> Effect String
+foreign import setSearch :: String -> Location -> Effect Unit
 
-foreign import assign :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
-foreign import replace :: forall eff. String -> Location -> Eff (dom :: DOM | eff) Unit
-foreign import reload :: forall eff. Location -> Eff (dom :: DOM | eff) Unit
+foreign import assign :: String -> Location -> Effect Unit
+foreign import replace :: String -> Location -> Effect Unit
+foreign import reload :: Location -> Effect Unit

--- a/src/DOM/HTML/Navigator.purs
+++ b/src/DOM/HTML/Navigator.purs
@@ -1,7 +1,6 @@
 module DOM.HTML.Navigator where
 
-import Control.Monad.Eff (Eff)
-import DOM (DOM)
+import Control.Monad.Effect (Effect)
 import DOM.HTML.Types (Navigator)
 
-foreign import platform :: forall eff. Navigator -> Eff (dom :: DOM | eff) String
+foreign import platform :: Navigator -> Effect String

--- a/src/DOM/HTML/Types.purs
+++ b/src/DOM/HTML/Types.purs
@@ -5,11 +5,6 @@ module DOM.HTML.Types
   , History
   , URL
   , Window
-  , ALERT
-  , CONFIRM
-  , HISTORY
-  , PROMPT
-  , WINDOW
   , windowToEventTarget
   , HTMLDocument
   , htmlDocumentToDocument
@@ -215,7 +210,6 @@ module DOM.HTML.Types
   ) where
 
 import Prelude
-import Control.Monad.Eff (kind Effect)
 import Control.Monad.Except.Trans (except)
 import Data.Either (Either(..))
 import Data.Foreign (Foreign, F, ForeignError(..), unsafeReadTagged)
@@ -233,16 +227,6 @@ foreign import data Window :: Type
 foreign import data History :: Type
 
 foreign import data URL :: Type
-
-foreign import data ALERT :: Effect
-
-foreign import data HISTORY :: Effect
-
-foreign import data PROMPT :: Effect
-
-foreign import data CONFIRM :: Effect
-
-foreign import data WINDOW :: Effect
 
 windowToEventTarget :: Window -> EventTarget
 windowToEventTarget = U.unsafeCoerce

--- a/src/DOM/HTML/URL.purs
+++ b/src/DOM/HTML/URL.purs
@@ -3,12 +3,11 @@ module DOM.HTML.URL
   , revokeObjectURL
   ) where
 
-import Control.Monad.Eff (Eff)
-import DOM (DOM)
+import Control.Monad.Effect (Effect)
 import DOM.File.Types (File)
 import DOM.HTML.Types (URL)
 import Data.Unit (Unit)
 
-foreign import createObjectURL :: forall eff. File -> URL -> Eff (dom :: DOM | eff) String
+foreign import createObjectURL :: File -> URL -> Effect String
 
-foreign import revokeObjectURL :: forall eff. String -> URL -> Eff (dom :: DOM | eff) Unit
+foreign import revokeObjectURL :: String -> URL -> Effect Unit

--- a/src/DOM/HTML/Window.purs
+++ b/src/DOM/HTML/Window.purs
@@ -34,81 +34,79 @@ module DOM.HTML.Window
   , RequestIdleCallbackId
   ) where
 
-import Control.Monad.Eff (Eff)
-import DOM (DOM)
-import DOM.HTML.Types (ALERT, CONFIRM, HISTORY, HTMLDocument, History, Location, Navigator, PROMPT, WINDOW, Window, URL)
+import Control.Monad.Effect (Effect)
+import DOM.HTML.Types (HTMLDocument, History, Location, Navigator, Window, URL)
 import DOM.WebStorage.Types (Storage)
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 import Data.Newtype (class Newtype, unwrap)
 import Prelude (class Eq, class Ord, Unit, (<$>), (<<<), map)
 
-foreign import document :: forall eff. Window -> Eff (dom :: DOM | eff) HTMLDocument
+foreign import document :: Window -> Effect HTMLDocument
 
-foreign import navigator :: forall eff. Window -> Eff (dom :: DOM | eff) Navigator
+foreign import navigator :: Window -> Effect Navigator
 
-foreign import location :: forall eff. Window -> Eff (dom :: DOM | eff) Location
+foreign import location :: Window -> Effect Location
 
-foreign import history :: forall e. Window -> Eff (history :: HISTORY | e) History
+foreign import history :: Window -> Effect History
 
-foreign import url :: forall eff. Window -> Eff (dom :: DOM | eff) URL
+foreign import url :: Window -> Effect URL
 
-foreign import innerWidth :: forall eff. Window -> Eff (dom :: DOM | eff) Int
+foreign import innerWidth :: Window -> Effect Int
 
-foreign import innerHeight :: forall eff. Window -> Eff (dom :: DOM | eff) Int
+foreign import innerHeight :: Window -> Effect Int
 
-foreign import alert :: forall eff. String -> Window -> Eff (alert :: ALERT | eff) Unit
+foreign import alert :: String -> Window -> Effect Unit
 
-foreign import confirm :: forall eff. String -> Window -> Eff (confirm :: CONFIRM | eff) Boolean
+foreign import confirm :: String -> Window -> Effect Boolean
 
-foreign import moveBy :: forall eff. Int -> Int -> Window -> Eff (window :: WINDOW | eff) Unit
+foreign import moveBy :: Int -> Int -> Window -> Effect Unit
 
-foreign import moveTo :: forall eff. Int -> Int -> Window -> Eff (window :: WINDOW | eff) Unit
+foreign import moveTo :: Int -> Int -> Window -> Effect Unit
 
-open :: forall eff. String -> String -> String -> Window -> Eff (window :: WINDOW | eff) (Maybe Window)
+open :: String -> String -> String -> Window -> Effect (Maybe Window)
 open url' name features window = toMaybe <$> _open url' name features window
 
 foreign import _open
-  :: forall eff
-   . String
+  :: String
   -> String
   -> String
   -> Window
-  -> Eff (window :: WINDOW | eff) (Nullable Window)
+  -> Effect (Nullable Window)
 
-foreign import outerHeight :: forall eff. Window -> Eff (dom :: DOM | eff) Int
+foreign import outerHeight :: Window -> Effect Int
 
-foreign import outerWidth :: forall eff. Window -> Eff (dom :: DOM | eff) Int
+foreign import outerWidth :: Window -> Effect Int
 
-foreign import print :: forall eff. Window -> Eff (window :: WINDOW | eff) Unit
+foreign import print :: Window -> Effect Unit
 
-prompt :: forall eff. String -> Window -> Eff (prompt :: PROMPT | eff) (Maybe String)
+prompt :: String -> Window -> Effect (Maybe String)
 prompt msg window = toMaybe <$> _prompt msg "" window
 
-promptDefault :: forall eff. String -> String -> Window -> Eff (prompt :: PROMPT | eff) (Maybe String)
+promptDefault :: String -> String -> Window -> Effect (Maybe String)
 promptDefault msg defaultText window = toMaybe <$> _prompt msg defaultText window
 
-foreign import _prompt :: forall eff. String -> String -> Window -> Eff (prompt :: PROMPT | eff) (Nullable String)
+foreign import _prompt :: String -> String -> Window -> Effect (Nullable String)
 
-foreign import resizeBy :: forall eff. Int -> Int -> Window -> Eff (window :: WINDOW | eff) Unit
+foreign import resizeBy :: Int -> Int -> Window -> Effect Unit
 
-foreign import resizeTo :: forall eff. Int -> Int -> Window -> Eff (window :: WINDOW | eff) Unit
+foreign import resizeTo :: Int -> Int -> Window -> Effect Unit
 
-foreign import screenX :: forall eff. Window -> Eff (dom :: DOM | eff) Int
+foreign import screenX :: Window -> Effect Int
 
-foreign import screenY :: forall eff. Window -> Eff (dom :: DOM | eff) Int
+foreign import screenY :: Window -> Effect Int
 
-foreign import scroll :: forall eff. Int -> Int -> Window -> Eff (window :: WINDOW | eff) Unit
+foreign import scroll :: Int -> Int -> Window -> Effect Unit
 
-foreign import scrollBy :: forall eff. Int -> Int -> Window -> Eff (window :: WINDOW | eff) Unit
+foreign import scrollBy :: Int -> Int -> Window -> Effect Unit
 
-foreign import scrollX :: forall eff. Window -> Eff (dom :: DOM | eff) Int
+foreign import scrollX :: Window -> Effect Int
 
-foreign import scrollY :: forall eff. Window -> Eff (dom :: DOM | eff) Int
+foreign import scrollY :: Window -> Effect Int
 
-foreign import localStorage :: forall eff. Window -> Eff (dom :: DOM | eff) Storage
+foreign import localStorage :: Window -> Effect Storage
 
-foreign import sessionStorage :: forall eff. Window -> Eff (dom :: DOM | eff) Storage
+foreign import sessionStorage :: Window -> Effect Storage
 
 newtype RequestAnimationFrameId = RequestAnimationFrameId Int
 
@@ -116,14 +114,14 @@ derive instance newtypeRequestAnimationFrameId :: Newtype RequestAnimationFrameI
 derive instance eqRequestAnimationFrameId :: Eq RequestAnimationFrameId
 derive instance ordRequestAnimationFrameId :: Ord RequestAnimationFrameId
 
-foreign import _requestAnimationFrame :: forall eff. Eff (dom :: DOM | eff) Unit -> Window -> Eff (dom :: DOM | eff) Int
+foreign import _requestAnimationFrame :: Effect Unit -> Window -> Effect Int
 
-requestAnimationFrame :: forall eff. Eff (dom :: DOM | eff) Unit -> Window -> Eff (dom :: DOM | eff ) RequestAnimationFrameId
+requestAnimationFrame :: Effect Unit -> Window -> Effect RequestAnimationFrameId
 requestAnimationFrame fn = map RequestAnimationFrameId <<< _requestAnimationFrame fn
 
-foreign import _cancelAnimationFrame :: forall eff. Int -> Window -> Eff (dom :: DOM | eff) Unit
+foreign import _cancelAnimationFrame :: Int -> Window -> Effect Unit
 
-cancelAnimationFrame :: forall eff. RequestAnimationFrameId -> Window -> Eff (dom :: DOM | eff) Unit
+cancelAnimationFrame :: RequestAnimationFrameId -> Window -> Effect Unit
 cancelAnimationFrame idAF = _cancelAnimationFrame (unwrap idAF)
 
 newtype RequestIdleCallbackId = RequestIdleCallbackId Int
@@ -132,14 +130,14 @@ derive instance newtypeRequestIdleCallbackId :: Newtype RequestIdleCallbackId _
 derive instance eqRequestIdleCallbackId :: Eq RequestIdleCallbackId
 derive instance ordRequestIdleCallbackId :: Ord RequestIdleCallbackId
 
-foreign import _requestIdleCallback :: forall eff. { timeout :: Int } -> Eff (dom :: DOM | eff) Unit -> Window -> Eff (dom :: DOM | eff) Int 
+foreign import _requestIdleCallback :: { timeout :: Int } -> Effect Unit -> Window -> Effect Int 
 
 -- | Set timeout to `0` to get the same behaviour as when it is `undefined` in
 -- | [JavaScript](https://w3c.github.io/requestidlecallback/#h-the-requestidle-callback-method).
-requestIdleCallback :: forall eff. { timeout :: Int } -> Eff (dom :: DOM | eff) Unit -> Window -> Eff (dom :: DOM | eff ) RequestIdleCallbackId
+requestIdleCallback :: { timeout :: Int } -> Effect Unit -> Window -> Effect RequestIdleCallbackId
 requestIdleCallback opts fn = map RequestIdleCallbackId <<< _requestIdleCallback opts fn
 
-foreign import _cancelIdleCallback :: forall eff. Int -> Window -> Eff (dom :: DOM | eff) Unit
+foreign import _cancelIdleCallback :: Int -> Window -> Effect Unit
 
-cancelIdleCallback :: forall eff. RequestIdleCallbackId -> Window -> Eff (dom :: DOM | eff) Unit
+cancelIdleCallback :: RequestIdleCallbackId -> Window -> Effect Unit
 cancelIdleCallback idAF = _cancelIdleCallback (unwrap idAF)

--- a/src/DOM/Node/ChildNode.purs
+++ b/src/DOM/Node/ChildNode.purs
@@ -1,9 +1,8 @@
 module DOM.Node.ChildNode where
 
 import Prelude
-import Control.Monad.Eff (Eff)
-import DOM (DOM)
+import Control.Monad.Effect (Effect)
 import DOM.Node.Types (ChildNode)
 
 -- | Removes the node from its parent.
-foreign import remove :: forall eff. ChildNode -> Eff (dom :: DOM | eff) Unit
+foreign import remove :: ChildNode -> Effect Unit

--- a/src/DOM/Node/DOMTokenList.purs
+++ b/src/DOM/Node/DOMTokenList.purs
@@ -9,23 +9,22 @@ module DOM.Node.ClassList
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
-import DOM (DOM)
+import Control.Monad.Effect (Effect)
 import DOM.Node.Types (DOMTokenList)
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 
-foreign import add :: forall eff. DOMTokenList -> String -> Eff (dom :: DOM | eff) Unit
+foreign import add :: DOMTokenList -> String -> Effect Unit
 
-foreign import remove :: forall eff. DOMTokenList -> String -> Eff (dom :: DOM | eff) Unit
+foreign import remove :: DOMTokenList -> String -> Effect Unit
 
-foreign import contains :: forall eff. DOMTokenList -> String -> Eff (dom :: DOM | eff) Boolean
+foreign import contains :: DOMTokenList -> String -> Effect Boolean
 
-foreign import toggle :: forall eff. DOMTokenList -> String -> Eff (dom :: DOM | eff) Boolean
+foreign import toggle :: DOMTokenList -> String -> Effect Boolean
 
-foreign import toggleForce :: forall eff. DOMTokenList -> String -> Boolean -> Eff (dom :: DOM | eff) Boolean
+foreign import toggleForce :: DOMTokenList -> String -> Boolean -> Effect Boolean
 
-foreign import _item :: forall eff. DOMTokenList -> Int -> Eff (dom :: DOM | eff) (Nullable String)
+foreign import _item :: DOMTokenList -> Int -> Effect (Nullable String)
 
-item :: forall eff. DOMTokenList -> Int -> Eff (dom :: DOM | eff) (Maybe String)
+item :: DOMTokenList -> Int -> Effect (Maybe String)
 item index = map toMaybe <<< _item index

--- a/src/DOM/Node/Document.purs
+++ b/src/DOM/Node/Document.purs
@@ -21,47 +21,46 @@ module DOM.Node.Document
   ) where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe, toNullable)
-import DOM (DOM)
 import DOM.Node.Types (Node, Document, ProcessingInstruction, Comment, Text, DocumentFragment, Element, HTMLCollection, DocumentType)
 
-foreign import url :: forall eff. Document -> Eff (dom :: DOM | eff) String
-foreign import documentURI :: forall eff. Document -> Eff (dom :: DOM | eff) String
-foreign import origin :: forall eff. Document -> Eff (dom :: DOM | eff) String
-foreign import compatMode :: forall eff. Document -> Eff (dom :: DOM | eff) String
-foreign import characterSet :: forall eff. Document -> Eff (dom :: DOM | eff) String
-foreign import contentType :: forall eff. Document -> Eff (dom :: DOM | eff) String
+foreign import url :: Document -> Effect String
+foreign import documentURI :: Document -> Effect String
+foreign import origin :: Document -> Effect String
+foreign import compatMode :: Document -> Effect String
+foreign import characterSet :: Document -> Effect String
+foreign import contentType :: Document -> Effect String
 
-doctype :: forall eff. Document -> Eff (dom :: DOM | eff) (Maybe DocumentType)
+doctype :: Document -> Effect (Maybe DocumentType)
 doctype = map toMaybe <<< _doctype
 
-foreign import _doctype :: forall eff. Document -> Eff (dom :: DOM | eff) (Nullable DocumentType)
+foreign import _doctype :: Document -> Effect (Nullable DocumentType)
 
-documentElement :: forall eff. Document -> Eff (dom :: DOM | eff) (Maybe Element)
+documentElement :: Document -> Effect (Maybe Element)
 documentElement = map toMaybe <<< _documentElement
 
-foreign import _documentElement :: forall eff. Document -> Eff (dom :: DOM | eff) (Nullable Element)
+foreign import _documentElement :: Document -> Effect (Nullable Element)
 
-foreign import getElementsByTagName :: forall eff. String -> Document -> Eff (dom :: DOM | eff) HTMLCollection
+foreign import getElementsByTagName :: String -> Document -> Effect HTMLCollection
 
-getElementsByTagNameNS :: forall eff. Maybe String -> String -> Document -> Eff (dom :: DOM | eff) HTMLCollection
+getElementsByTagNameNS :: Maybe String -> String -> Document -> Effect HTMLCollection
 getElementsByTagNameNS = _getElementsByTagNameNS <<< toNullable
 
-foreign import _getElementsByTagNameNS :: forall eff. Nullable String -> String -> Document -> Eff (dom :: DOM | eff) HTMLCollection
-foreign import getElementsByClassName :: forall eff. String -> Document -> Eff (dom :: DOM | eff) HTMLCollection
+foreign import _getElementsByTagNameNS :: Nullable String -> String -> Document -> Effect HTMLCollection
+foreign import getElementsByClassName :: String -> Document -> Effect HTMLCollection
 
-foreign import createElement :: forall eff. String -> Document -> Eff (dom :: DOM | eff) Element
+foreign import createElement :: String -> Document -> Effect Element
 
-createElementNS :: forall eff. Maybe String -> String -> Document -> Eff (dom :: DOM | eff) Element
+createElementNS :: Maybe String -> String -> Document -> Effect Element
 createElementNS = _createElementNS <<< toNullable
 
-foreign import _createElementNS :: forall eff. Nullable String -> String -> Document -> Eff (dom :: DOM | eff) Element
-foreign import createDocumentFragment :: forall eff. Document -> Eff (dom :: DOM | eff) DocumentFragment
-foreign import createTextNode :: forall eff. String -> Document -> Eff (dom :: DOM | eff) Text
-foreign import createComment :: forall eff. String -> Document -> Eff (dom :: DOM | eff) Comment
-foreign import createProcessingInstruction :: forall eff. String -> String -> Document -> Eff (dom :: DOM | eff) ProcessingInstruction
+foreign import _createElementNS :: Nullable String -> String -> Document -> Effect Element
+foreign import createDocumentFragment :: Document -> Effect DocumentFragment
+foreign import createTextNode :: String -> Document -> Effect Text
+foreign import createComment :: String -> Document -> Effect Comment
+foreign import createProcessingInstruction :: String -> String -> Document -> Effect ProcessingInstruction
 
-foreign import importNode :: forall eff. Node -> Boolean -> Document -> Eff (dom :: DOM | eff) Node
-foreign import adoptNode :: forall eff. Node -> Document -> Eff (dom :: DOM | eff) Node
+foreign import importNode :: Node -> Boolean -> Document -> Effect Node
+foreign import adoptNode :: Node -> Document -> Effect Node

--- a/src/DOM/Node/Element.purs
+++ b/src/DOM/Node/Element.purs
@@ -27,10 +27,9 @@ module DOM.Node.Element
   ) where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe, toNullable)
-import DOM (DOM)
 import DOM.Node.Types (Element, HTMLCollection, ElementId)
 
 namespaceURI :: Element -> Maybe String
@@ -44,38 +43,38 @@ foreign import _prefix :: Element -> Nullable String
 foreign import localName :: Element -> String
 foreign import tagName :: Element -> String
 
-foreign import id :: forall eff. Element -> Eff (dom :: DOM | eff) ElementId
-foreign import setId :: forall eff. ElementId -> Element -> Eff (dom :: DOM | eff) Unit
-foreign import className :: forall eff. Element -> Eff (dom :: DOM | eff) String
-foreign import setClassName :: forall eff. String -> Element -> Eff (dom :: DOM | eff) Unit
+foreign import id :: Element -> Effect ElementId
+foreign import setId :: ElementId -> Element -> Effect Unit
+foreign import className :: Element -> Effect String
+foreign import setClassName :: String -> Element -> Effect Unit
 
-foreign import getElementsByTagName :: forall eff. String -> Element -> Eff (dom :: DOM | eff) HTMLCollection
+foreign import getElementsByTagName :: String -> Element -> Effect HTMLCollection
 
-getElementsByTagNameNS :: forall eff. Maybe String -> String -> Element -> Eff (dom :: DOM | eff) HTMLCollection
+getElementsByTagNameNS :: Maybe String -> String -> Element -> Effect HTMLCollection
 getElementsByTagNameNS = _getElementsByTagNameNS <<< toNullable
 
-foreign import _getElementsByTagNameNS :: forall eff. Nullable String -> String -> Element -> Eff (dom :: DOM | eff) HTMLCollection
+foreign import _getElementsByTagNameNS :: Nullable String -> String -> Element -> Effect HTMLCollection
 
-foreign import getElementsByClassName :: forall eff. String -> Element -> Eff (dom :: DOM | eff) HTMLCollection
+foreign import getElementsByClassName :: String -> Element -> Effect HTMLCollection
 
-foreign import setAttribute :: forall eff. String -> String -> Element -> Eff (dom :: DOM | eff) Unit
+foreign import setAttribute :: String -> String -> Element -> Effect Unit
 
-getAttribute :: forall eff. String -> Element -> Eff (dom :: DOM | eff) (Maybe String)
+getAttribute :: String -> Element -> Effect (Maybe String)
 getAttribute attr = map toMaybe <<< _getAttribute attr
 
-foreign import _getAttribute :: forall eff. String -> Element -> Eff (dom :: DOM | eff) (Nullable String)
-foreign import hasAttribute :: forall eff. String -> Element -> Eff (dom :: DOM | eff) Boolean
-foreign import removeAttribute :: forall eff. String -> Element -> Eff (dom :: DOM | eff) Unit
+foreign import _getAttribute :: String -> Element -> Effect (Nullable String)
+foreign import hasAttribute :: String -> Element -> Effect Boolean
+foreign import removeAttribute :: String -> Element -> Effect Unit
 
-foreign import scrollTop :: forall eff. Element -> Eff (dom :: DOM | eff) Number
-foreign import setScrollTop :: forall eff. Number -> Element -> Eff (dom :: DOM | eff) Unit
+foreign import scrollTop :: Element -> Effect Number
+foreign import setScrollTop :: Number -> Element -> Effect Unit
 
-foreign import scrollLeft :: forall eff. Element -> Eff (dom :: DOM | eff) Number
-foreign import setScrollLeft :: forall eff. Number -> Element -> Eff (dom :: DOM | eff) Unit
+foreign import scrollLeft :: Element -> Effect Number
+foreign import setScrollLeft :: Number -> Element -> Effect Unit
 
-foreign import scrollWidth :: forall eff. Element -> Eff (dom :: DOM | eff) Number
-foreign import scrollHeight :: forall eff. Element -> Eff (dom :: DOM | eff) Number
-foreign import clientTop :: forall eff. Element -> Eff (dom :: DOM | eff) Number
-foreign import clientLeft :: forall eff. Element -> Eff (dom :: DOM | eff) Number
-foreign import clientWidth :: forall eff. Element -> Eff (dom :: DOM | eff) Number
-foreign import clientHeight :: forall eff. Element -> Eff (dom :: DOM | eff) Number
+foreign import scrollWidth :: Element -> Effect Number
+foreign import scrollHeight :: Element -> Effect Number
+foreign import clientTop :: Element -> Effect Number
+foreign import clientLeft :: Element -> Effect Number
+foreign import clientWidth :: Element -> Effect Number
+foreign import clientHeight :: Element -> Effect Number

--- a/src/DOM/Node/HTMLCollection.purs
+++ b/src/DOM/Node/HTMLCollection.purs
@@ -6,28 +6,27 @@ module DOM.Node.HTMLCollection
   ) where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
-import DOM (DOM)
 import DOM.Node.Types (Element, HTMLCollection, ElementId)
 
 -- | The number of elements in a HTMLCollection.
-foreign import length :: forall eff. HTMLCollection -> Eff (dom :: DOM | eff) Int
+foreign import length :: HTMLCollection -> Effect Int
 
 -- | The elements of an HTMLCollection represented in an array.
-foreign import toArray :: forall eff. HTMLCollection -> Eff (dom :: DOM | eff) (Array Element)
+foreign import toArray :: HTMLCollection -> Effect (Array Element)
 
 -- | The element in a HTMLCollection at the specified index, or Nothing if no such
 -- | element exists.
-item :: forall eff. Int -> HTMLCollection -> Eff (dom :: DOM | eff) (Maybe Element)
+item :: Int -> HTMLCollection -> Effect (Maybe Element)
 item i = map toMaybe <<< _item i
 
-foreign import _item :: forall eff. Int -> HTMLCollection -> Eff (dom :: DOM | eff) (Nullable Element)
+foreign import _item :: Int -> HTMLCollection -> Effect (Nullable Element)
 
 -- | The first element with the specified name or ID in a HTMLCollection, or
 -- | Nothing if no such element exists.
-namedItem :: forall eff. ElementId -> HTMLCollection -> Eff (dom :: DOM | eff) (Maybe Element)
+namedItem :: ElementId -> HTMLCollection -> Effect (Maybe Element)
 namedItem id = map toMaybe <<< _namedItem id
 
-foreign import _namedItem :: forall eff. ElementId -> HTMLCollection -> Eff (dom :: DOM | eff) (Nullable Element)
+foreign import _namedItem :: ElementId -> HTMLCollection -> Effect (Nullable Element)

--- a/src/DOM/Node/MutationObserver.purs
+++ b/src/DOM/Node/MutationObserver.purs
@@ -9,8 +9,7 @@ module DOM.Node.MutationObserver
 
 import Prelude
 
-import Control.Monad.Eff (Eff, kind Effect)
-import DOM (DOM)
+import Control.Monad.Effect (Effect)
 import DOM.Node.MutationRecord (MutationRecord)
 import DOM.Node.Types (Node)
 
@@ -27,21 +26,20 @@ type MutationObserverInitFields =
   )
 
 foreign import mutationObserver
-  :: forall eff
-   . (MutationRecord -> MutationObserver -> Eff (dom :: DOM | eff) Unit)
-  -> Eff (dom :: DOM | eff) MutationObserver
+  :: (MutationRecord -> MutationObserver -> Effect Unit)
+  -> Effect MutationObserver
 
-foreign import _observe :: forall eff r. Node -> Record r -> MutationObserver -> Eff (dom :: DOM | eff) Unit
+foreign import _observe :: forall r. Node -> Record r -> MutationObserver -> Effect Unit
 
 observe
-  :: forall eff r rx
+  :: forall r rx
    . Union r rx MutationObserverInitFields
   => Node
   -> Record r
   -> MutationObserver
-  -> Eff (dom :: DOM | eff) Unit
+  -> Effect Unit
 observe = _observe
 
-foreign import disconnect :: forall eff. MutationObserver -> Eff (dom :: DOM | eff) Unit
+foreign import disconnect :: MutationObserver -> Effect Unit
 
-foreign import takeRecords :: forall eff. MutationObserver -> Eff (dom :: DOM | eff) (Array MutationRecord)
+foreign import takeRecords :: MutationObserver -> Effect (Array MutationRecord)

--- a/src/DOM/Node/MutationRecord.purs
+++ b/src/DOM/Node/MutationRecord.purs
@@ -15,8 +15,7 @@ module DOM.Node.MutationRecord
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
-import DOM (DOM)
+import Control.Monad.Effect (Effect)
 import DOM.Node.Types (Node, NodeList)
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
@@ -28,9 +27,9 @@ data MutationRecordType
   | MutationRecordCharacterData
   | MutationRecordChildList
 
-foreign import typeString :: forall eff. MutationRecord -> Eff (dom :: DOM | eff) String
+foreign import typeString :: MutationRecord -> Effect String
 
-type_ :: forall eff. Partial => MutationRecord -> Eff (dom :: DOM | eff) MutationRecordType
+type_ :: Partial => MutationRecord -> Effect MutationRecordType
 type_ = map stringToType <<< typeString
   where
   stringToType = case _ of
@@ -38,33 +37,33 @@ type_ = map stringToType <<< typeString
     "characterData" -> MutationRecordCharacterData
     "childList" -> MutationRecordChildList
 
-foreign import target :: forall eff. MutationRecord -> Eff (dom :: DOM | eff) Node
+foreign import target :: MutationRecord -> Effect Node
 
-foreign import addedNodes :: forall eff. MutationRecord -> Eff (dom :: DOM | eff) NodeList
+foreign import addedNodes :: MutationRecord -> Effect NodeList
 
-foreign import removedNodes :: forall eff. MutationRecord -> Eff (dom :: DOM | eff) NodeList
+foreign import removedNodes :: MutationRecord -> Effect NodeList
 
-foreign import _nextSibling :: forall eff. MutationRecord -> Eff (dom :: DOM | eff) (Nullable Node)
+foreign import _nextSibling :: MutationRecord -> Effect (Nullable Node)
 
-nextSibling :: forall eff. MutationRecord -> Eff (dom :: DOM | eff) (Maybe Node)
+nextSibling :: MutationRecord -> Effect (Maybe Node)
 nextSibling = map toMaybe <<< _nextSibling
 
-foreign import _previousSibling :: forall eff. MutationRecord -> Eff (dom :: DOM | eff) (Nullable Node)
+foreign import _previousSibling :: MutationRecord -> Effect (Nullable Node)
 
-previousSibling :: forall eff. MutationRecord -> Eff (dom :: DOM | eff) (Maybe Node)
+previousSibling :: MutationRecord -> Effect (Maybe Node)
 previousSibling = map toMaybe <<< _previousSibling
 
-foreign import _attributeName :: forall eff. MutationRecord -> Eff (dom :: DOM | eff) (Nullable String)
+foreign import _attributeName :: MutationRecord -> Effect (Nullable String)
 
-attributeName :: forall eff. MutationRecord -> Eff (dom :: DOM | eff) (Maybe String)
+attributeName :: MutationRecord -> Effect (Maybe String)
 attributeName = map toMaybe <<< _attributeName
 
-foreign import _attributeNamespace :: forall eff. MutationRecord -> Eff (dom :: DOM | eff) (Nullable String)
+foreign import _attributeNamespace :: MutationRecord -> Effect (Nullable String)
 
-attributeNamespace :: forall eff. MutationRecord -> Eff (dom :: DOM | eff) (Maybe String)
+attributeNamespace :: MutationRecord -> Effect (Maybe String)
 attributeNamespace = map toMaybe <<< _attributeNamespace
 
-foreign import _oldValue :: forall eff. MutationRecord -> Eff (dom :: DOM | eff) (Nullable String)
+foreign import _oldValue :: MutationRecord -> Effect (Nullable String)
 
-oldValue :: forall eff. MutationRecord -> Eff (dom :: DOM | eff) (Maybe String)
+oldValue :: MutationRecord -> Effect (Maybe String)
 oldValue = map toMaybe <<< _oldValue

--- a/src/DOM/Node/Node.purs
+++ b/src/DOM/Node/Node.purs
@@ -32,11 +32,10 @@ module DOM.Node.Node
   ) where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 import Data.Enum (toEnum)
 import Data.Maybe (Maybe, fromJust)
 import Data.Nullable (Nullable, toMaybe)
-import DOM (DOM)
 import DOM.Node.NodeType (NodeType)
 import DOM.Node.Types (Node, NodeList, Element, Document)
 
@@ -54,118 +53,118 @@ foreign import nodeTypeIndex :: Node -> Int
 foreign import nodeName :: Node -> String
 
 -- | The node's base URL.
-foreign import baseURI :: forall eff. Node -> Eff (dom :: DOM | eff) String
+foreign import baseURI :: Node -> Effect String
 
 -- | The document the node belongs to, unless the node is a document in which
 -- | case the value is Nothing.
-ownerDocument :: forall eff. Node -> Eff (dom :: DOM | eff) (Maybe Document)
+ownerDocument :: Node -> Effect (Maybe Document)
 ownerDocument = map toMaybe <<< _ownerDocument
 
-foreign import _ownerDocument :: forall eff. Node -> Eff (dom :: DOM | eff) (Nullable Document)
+foreign import _ownerDocument :: Node -> Effect (Nullable Document)
 
 -- | The parent node of the node.
-parentNode :: forall eff. Node -> Eff (dom :: DOM | eff) (Maybe Node)
+parentNode :: Node -> Effect (Maybe Node)
 parentNode = map toMaybe <<< _parentNode
 
-foreign import _parentNode :: forall eff. Node -> Eff (dom :: DOM | eff) (Nullable Node)
+foreign import _parentNode :: Node -> Effect (Nullable Node)
 
 -- | The parent element of the node.
-parentElement :: forall eff. Node -> Eff (dom :: DOM | eff) (Maybe Element)
+parentElement :: Node -> Effect (Maybe Element)
 parentElement = map toMaybe <<< _parentElement
 
-foreign import _parentElement :: forall eff. Node -> Eff (dom :: DOM | eff) (Nullable Element)
+foreign import _parentElement :: Node -> Effect (Nullable Element)
 
 -- | Indicates whether the node has any child nodes.
-foreign import hasChildNodes :: forall eff. Node -> Eff (dom :: DOM | eff) Boolean
+foreign import hasChildNodes :: Node -> Effect Boolean
 
 -- | The children of the node.
-foreign import childNodes :: forall eff. Node -> Eff (dom :: DOM | eff) NodeList
+foreign import childNodes :: Node -> Effect NodeList
 
 -- | The first child of the node, or Nothing if the node has no children.
-firstChild :: forall eff. Node -> Eff (dom :: DOM | eff) (Maybe Node)
+firstChild :: Node -> Effect (Maybe Node)
 firstChild = map toMaybe <<< _firstChild
 
-foreign import _firstChild :: forall eff. Node -> Eff (dom :: DOM | eff) (Nullable Node)
+foreign import _firstChild :: Node -> Effect (Nullable Node)
 
 
 -- | The last child of the node, or Nothing if the node has no children.
-lastChild :: forall eff. Node -> Eff (dom :: DOM | eff) (Maybe Node)
+lastChild :: Node -> Effect (Maybe Node)
 lastChild = map toMaybe <<< _lastChild
 
-foreign import _lastChild :: forall eff. Node -> Eff (dom :: DOM | eff) (Nullable Node)
+foreign import _lastChild :: Node -> Effect (Nullable Node)
 
 -- | The previous sibling node, or Nothing if there is no previous sibling.
-previousSibling :: forall eff. Node -> Eff (dom :: DOM | eff) (Maybe Node)
+previousSibling :: Node -> Effect (Maybe Node)
 previousSibling = map toMaybe <<< _previousSibling
 
-foreign import _previousSibling :: forall eff. Node -> Eff (dom :: DOM | eff) (Nullable Node)
+foreign import _previousSibling :: Node -> Effect (Nullable Node)
 
 -- | The next sibling node, or Nothing if there is no next sibling.
-nextSibling :: forall eff. Node -> Eff (dom :: DOM | eff) (Maybe Node)
+nextSibling :: Node -> Effect (Maybe Node)
 nextSibling = map toMaybe <<< _nextSibling
 
-foreign import _nextSibling :: forall eff. Node -> Eff (dom :: DOM | eff) (Nullable Node)
+foreign import _nextSibling :: Node -> Effect (Nullable Node)
 
 -- | If the node type is text, comment, or processing instruction this is the
 -- | node's data, or null in all other cases.
-foreign import nodeValue :: forall eff. Node -> Eff (dom :: DOM | eff) String
+foreign import nodeValue :: Node -> Effect String
 
 -- | If the node type is text, comment, or processing instruction this allows
 -- | the node's data to be changed, or has no effect in all other cases.
-foreign import setNodeValue :: forall eff. String -> Node -> Eff (dom :: DOM | eff) Unit
+foreign import setNodeValue :: String -> Node -> Effect Unit
 
 -- | If the node type is document fragment, element, text, processing
 -- | instruction, or comment this is the node's data, or null in all other
 -- | cases.
-foreign import textContent :: forall eff. Node -> Eff (dom :: DOM | eff) String
+foreign import textContent :: Node -> Effect String
 
 -- | If the node type is document fragment, element, text, processing
 -- | instruction, or comment this allows the node's data to be changed, or has
 -- | no effect in all other cases.
-foreign import setTextContent :: forall eff. String -> Node -> Eff (dom :: DOM | eff) Unit
+foreign import setTextContent :: String -> Node -> Effect Unit
 
 -- | Removes empty text nodes and then combines any remaining text nodes that
 -- | are contiguous.
-foreign import normalize :: forall eff. Node -> Eff (dom :: DOM | eff) Unit
+foreign import normalize :: Node -> Effect Unit
 
 -- | Clones the node without cloning the node's descendants.
-foreign import clone :: forall eff. Node -> Eff (dom :: DOM | eff) Node
+foreign import clone :: Node -> Effect Node
 
 -- | Clones the node and its descendants.
-foreign import deepClone :: forall eff. Node -> Eff (dom :: DOM | eff) Node
+foreign import deepClone :: Node -> Effect Node
 
 -- | Checks whether two nodes are equivalent.
-foreign import isEqualNode :: forall eff. Node -> Node -> Eff (dom :: DOM | eff) Boolean
+foreign import isEqualNode :: Node -> Node -> Effect Boolean
 
 -- TODO: compareDocumentPosition that returns a semigroup or something instead of the bitmask value
 
 -- | Compares the position of two nodes in the document.
-foreign import compareDocumentPositionBits :: forall eff. Node -> Node -> Eff (dom :: DOM | eff) Int
+foreign import compareDocumentPositionBits :: Node -> Node -> Effect Int
 
 -- | Checks whether the second node is contained within the first
-foreign import contains :: forall eff. Node -> Node -> Eff (dom :: DOM | eff) Boolean
+foreign import contains :: Node -> Node -> Effect Boolean
 
-lookupPrefix :: forall eff. String -> Node -> Eff (dom :: DOM | eff) (Maybe String)
+lookupPrefix :: String -> Node -> Effect (Maybe String)
 lookupPrefix p = map toMaybe <<< _lookupPrefix p
 
-foreign import _lookupPrefix :: forall eff. String -> Node -> Eff (dom :: DOM | eff) (Nullable String)
+foreign import _lookupPrefix :: String -> Node -> Effect (Nullable String)
 
-lookupNamespaceURI :: forall eff. String -> Node -> Eff (dom :: DOM | eff) (Maybe String)
+lookupNamespaceURI :: String -> Node -> Effect (Maybe String)
 lookupNamespaceURI ns = map toMaybe <<< _lookupNamespaceURI ns
 
-foreign import _lookupNamespaceURI :: forall eff. String -> Node -> Eff (dom :: DOM | eff) (Nullable String)
+foreign import _lookupNamespaceURI :: String -> Node -> Effect (Nullable String)
 
-foreign import isDefaultNamespace :: forall eff. String -> Node -> Eff (dom :: DOM | eff) Boolean
+foreign import isDefaultNamespace :: String -> Node -> Effect Boolean
 
 -- | Inserts the first node before the second as a child of the third node.
-foreign import insertBefore :: forall eff. Node -> Node -> Node -> Eff (dom :: DOM | eff) Node
+foreign import insertBefore :: Node -> Node -> Node -> Effect Node
 
 -- | Appends the first node to the child node list of the second node.
-foreign import appendChild :: forall eff. Node -> Node -> Eff (dom :: DOM | eff) Node
+foreign import appendChild :: Node -> Node -> Effect Node
 
 -- | Uses the first node as a replacement for the second node in the children
 -- | of the third node.
-foreign import replaceChild :: forall eff. Node -> Node -> Node -> Eff (dom :: DOM | eff) Node
+foreign import replaceChild :: Node -> Node -> Node -> Effect Node
 
 -- | Removes the first node from the children of the second node.
-foreign import removeChild :: forall eff. Node -> Node -> Eff (dom :: DOM | eff) Node
+foreign import removeChild :: Node -> Node -> Effect Node

--- a/src/DOM/Node/NodeList.purs
+++ b/src/DOM/Node/NodeList.purs
@@ -5,21 +5,20 @@ module DOM.Node.NodeList
   ) where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
-import DOM (DOM)
 import DOM.Node.Types (Node, NodeList)
 
 -- | The number of items in a NodeList.
-foreign import length :: forall eff. NodeList -> Eff (dom :: DOM | eff) Int
+foreign import length :: NodeList -> Effect Int
 
 -- | The elements of a NodeList represented in an array.
-foreign import toArray :: forall eff. NodeList -> Eff (dom :: DOM | eff) (Array Node)
+foreign import toArray :: NodeList -> Effect (Array Node)
 
 -- | The item in a NodeList at the specified index, or Nothing if no such node
 -- | exists.
-item :: forall eff. Int -> NodeList -> Eff (dom :: DOM | eff) (Maybe Node)
+item :: Int -> NodeList -> Effect (Maybe Node)
 item i = map toMaybe <<< _item i
 
-foreign import _item :: forall eff. Int -> NodeList -> Eff (dom :: DOM | eff) (Nullable Node)
+foreign import _item :: Int -> NodeList -> Effect (Nullable Node)

--- a/src/DOM/Node/NonDocumentTypeChildNode.purs
+++ b/src/DOM/Node/NonDocumentTypeChildNode.purs
@@ -4,20 +4,19 @@ module DOM.Node.NonDocumentTypeChildNode
   ) where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
-import DOM (DOM)
 import DOM.Node.Types (Element, NonDocumentTypeChildNode)
 
 -- | The previous sibling that is an element, or Nothing if no such element exists.
-previousElementSibling :: forall eff. NonDocumentTypeChildNode -> Eff (dom :: DOM | eff) (Maybe Element)
+previousElementSibling :: NonDocumentTypeChildNode -> Effect (Maybe Element)
 previousElementSibling = map toMaybe <<< _previousElementSibling
 
-foreign import _previousElementSibling :: forall eff. NonDocumentTypeChildNode -> Eff (dom :: DOM | eff) (Nullable Element)
+foreign import _previousElementSibling :: NonDocumentTypeChildNode -> Effect (Nullable Element)
 
 -- | The next sibling that is an element, or Nothing if no such element exists.
-nextElementSibling :: forall eff. NonDocumentTypeChildNode -> Eff (dom :: DOM | eff) (Maybe Element)
+nextElementSibling :: NonDocumentTypeChildNode -> Effect (Maybe Element)
 nextElementSibling = map toMaybe <<< _nextElementSibling
 
-foreign import _nextElementSibling :: forall eff. NonDocumentTypeChildNode -> Eff (dom :: DOM | eff) (Nullable Element)
+foreign import _nextElementSibling :: NonDocumentTypeChildNode -> Effect (Nullable Element)

--- a/src/DOM/Node/NonElementParentNode.purs
+++ b/src/DOM/Node/NonElementParentNode.purs
@@ -3,15 +3,14 @@ module DOM.Node.NonElementParentNode
   ) where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
-import DOM (DOM)
 import DOM.Node.Types (Element, NonElementParentNode, ElementId)
 
 -- | The first element within node's descendants with a matching ID, or null if
 -- | no such element exists.
-foreign import _getElementById :: forall eff. ElementId -> NonElementParentNode -> Eff (dom :: DOM | eff) (Nullable Element)
+foreign import _getElementById :: ElementId -> NonElementParentNode -> Effect (Nullable Element)
 
-getElementById :: forall eff. ElementId -> NonElementParentNode -> Eff (dom :: DOM | eff) (Maybe Element)
+getElementById :: ElementId -> NonElementParentNode -> Effect (Maybe Element)
 getElementById eid = map toMaybe <<< _getElementById eid

--- a/src/DOM/Node/ParentNode.purs
+++ b/src/DOM/Node/ParentNode.purs
@@ -10,32 +10,31 @@ module DOM.Node.ParentNode
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
 import Data.Newtype (class Newtype)
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 
-import DOM (DOM)
 import DOM.Node.Types (NodeList, ParentNode, Element, HTMLCollection)
 
 -- | The child elements for the node.
-foreign import children :: forall eff. ParentNode -> Eff (dom :: DOM | eff) HTMLCollection
+foreign import children :: ParentNode -> Effect HTMLCollection
 
 -- | The first child that is an element, or Nothing if no such element exists.
-firstElementChild :: forall eff. ParentNode -> Eff (dom :: DOM | eff) (Maybe Element)
+firstElementChild :: ParentNode -> Effect (Maybe Element)
 firstElementChild = map toMaybe <<< _firstElementChild
 
-foreign import _firstElementChild :: forall eff. ParentNode -> Eff (dom :: DOM | eff) (Nullable Element)
+foreign import _firstElementChild :: ParentNode -> Effect (Nullable Element)
 
 -- | The last child that is an element, or Nothing if no such element exists.
-lastElementChild :: forall eff. ParentNode -> Eff (dom :: DOM | eff) (Maybe Element)
+lastElementChild :: ParentNode -> Effect (Maybe Element)
 lastElementChild = map toMaybe <<< _lastElementChild
 
-foreign import _lastElementChild :: forall eff. ParentNode -> Eff (dom :: DOM | eff) (Nullable Element)
+foreign import _lastElementChild :: ParentNode -> Effect (Nullable Element)
 
 -- | The number of child elements.
-foreign import childElementCount :: forall eff. ParentNode -> Eff (dom :: DOM | eff) Int
+foreign import childElementCount :: ParentNode -> Effect Int
 
 newtype QuerySelector = QuerySelector String
 
@@ -45,10 +44,10 @@ derive instance newtypeQuerySelector :: Newtype QuerySelector _
 
 -- | Finds the first child that is an element that matches the selector(s), or
 -- | Nothing if no such element exists.
-querySelector :: forall eff. QuerySelector -> ParentNode -> Eff (dom :: DOM | eff) (Maybe Element)
+querySelector :: QuerySelector -> ParentNode -> Effect (Maybe Element)
 querySelector qs = map toMaybe <<< _querySelector qs
 
-foreign import _querySelector :: forall eff. QuerySelector -> ParentNode -> Eff (dom :: DOM | eff) (Nullable Element)
+foreign import _querySelector :: QuerySelector -> ParentNode -> Effect (Nullable Element)
 
 -- | Finds all the child elements that matches the selector(s).
-foreign import querySelectorAll :: forall eff. QuerySelector -> ParentNode -> Eff (dom :: DOM | eff) NodeList
+foreign import querySelectorAll :: QuerySelector -> ParentNode -> Effect NodeList

--- a/src/DOM/WebStorage/Storage.purs
+++ b/src/DOM/WebStorage/Storage.purs
@@ -10,28 +10,27 @@ module DOM.WebStorage.Storage
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
-import DOM (DOM)
 import DOM.WebStorage.Types (Storage)
 
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 
-foreign import length :: forall eff. Storage -> Eff (dom :: DOM | eff) Int
+foreign import length :: Storage -> Effect Int
 
-foreign import _key :: forall eff. Int -> Storage -> Eff (dom :: DOM | eff) (Nullable String)
+foreign import _key :: Int -> Storage -> Effect (Nullable String)
 
-key :: forall eff. Int -> Storage -> Eff (dom :: DOM | eff) (Maybe String)
+key :: Int -> Storage -> Effect (Maybe String)
 key i = map toMaybe <<< _key i
 
-foreign import _getItem :: forall eff. String -> Storage -> Eff (dom :: DOM | eff) (Nullable String)
+foreign import _getItem :: String -> Storage -> Effect (Nullable String)
 
-getItem :: forall eff. String -> Storage -> Eff (dom :: DOM | eff) (Maybe String)
+getItem :: String -> Storage -> Effect (Maybe String)
 getItem s = map toMaybe <<< _getItem s
 
-foreign import setItem :: forall eff. String -> String -> Storage -> Eff (dom :: DOM | eff) Unit
+foreign import setItem :: String -> String -> Storage -> Effect Unit
 
-foreign import removeItem :: forall eff. String -> Storage -> Eff (dom :: DOM | eff) Unit
+foreign import removeItem :: String -> Storage -> Effect Unit
 
-foreign import clear :: forall eff. Storage -> Eff (dom :: DOM | eff) Unit
+foreign import clear :: Storage -> Effect Unit

--- a/src/DOM/Websocket/WebSocket.purs
+++ b/src/DOM/Websocket/WebSocket.purs
@@ -20,13 +20,12 @@ module DOM.Websocket.WebSocket
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Effect (Effect)
 
 import Data.ArrayBuffer.Types (ArrayBuffer, ArrayView)
 import Data.Foreign (Foreign, toForeign)
 import Data.Maybe (fromJust)
 
-import DOM (DOM)
 import DOM.File.Types (Blob)
 import DOM.Websocket.BinaryType (BinaryType(..), fromEnumBinaryType, printBinaryType, toEnumBinaryType)
 import DOM.Websocket.Event.Types (CloseEvent, MessageEvent, readCloseEvent, readMessageEvent)
@@ -35,46 +34,46 @@ import DOM.Websocket.Types (Protocol(..), URL(..), WebSocket, readWebSocket, soc
 
 import Partial.Unsafe (unsafePartial)
 
-foreign import create :: forall eff. URL -> Array Protocol -> Eff (dom :: DOM | eff) WebSocket
+foreign import create :: URL -> Array Protocol -> Effect WebSocket
 
-foreign import url :: forall eff. WebSocket -> Eff (dom :: DOM | eff) String
+foreign import url :: WebSocket -> Effect String
 
-foreign import readyStateImpl :: forall eff. WebSocket -> Eff (dom :: DOM | eff) Int
+foreign import readyStateImpl :: WebSocket -> Effect Int
 
-readyState :: forall eff. WebSocket -> Eff (dom :: DOM | eff) ReadyState
+readyState :: WebSocket -> Effect ReadyState
 readyState ws = do
   rs <- readyStateImpl ws
   pure $ unsafePartial $ fromJust $ toEnumReadyState rs
 
-foreign import bufferedAmount :: forall eff. WebSocket -> Eff (dom :: DOM | eff) Number
+foreign import bufferedAmount :: WebSocket -> Effect Number
 
-foreign import extensions :: forall eff. WebSocket -> Eff (dom :: DOM | eff) String
-foreign import protocol :: forall eff. WebSocket -> Eff (dom :: DOM | eff) String
+foreign import extensions :: WebSocket -> Effect String
+foreign import protocol :: WebSocket -> Effect String
 
-foreign import close :: forall eff. WebSocket -> Eff (dom :: DOM | eff) Unit
+foreign import close :: WebSocket -> Effect Unit
 
-foreign import getBinaryTypeImpl :: forall eff. WebSocket -> Eff (dom :: DOM | eff) String
-foreign import setBinaryTypeImpl :: forall eff. WebSocket -> String -> Eff (dom :: DOM | eff) Unit
+foreign import getBinaryTypeImpl :: WebSocket -> Effect String
+foreign import setBinaryTypeImpl :: WebSocket -> String -> Effect Unit
 
-getBinaryType :: forall eff. WebSocket -> Eff (dom :: DOM | eff) BinaryType
+getBinaryType :: WebSocket -> Effect BinaryType
 getBinaryType ws = unsafePartial do
   getBinaryTypeImpl ws <#> case _ of
     "blob" -> Blob
     "arraybuffer" -> ArrayBuffer
 
-setBinaryType :: forall eff. WebSocket -> BinaryType -> Eff (dom :: DOM | eff) Unit
+setBinaryType :: WebSocket -> BinaryType -> Effect Unit
 setBinaryType ws = setBinaryTypeImpl ws <<< printBinaryType
 
-foreign import sendImpl :: forall eff. WebSocket -> Foreign -> Eff (dom :: DOM | eff) Unit
+foreign import sendImpl :: WebSocket -> Foreign -> Effect Unit
 
-sendString :: forall eff. WebSocket -> String -> Eff (dom :: DOM | eff) Unit
+sendString :: WebSocket -> String -> Effect Unit
 sendString ws = sendImpl ws <<< toForeign
 
-sendBlob :: forall eff. WebSocket -> Blob -> Eff (dom :: DOM | eff) Unit
+sendBlob :: WebSocket -> Blob -> Effect Unit
 sendBlob ws = sendImpl ws <<< toForeign
 
-sendArrayBuffer :: forall eff. WebSocket -> ArrayBuffer -> Eff (dom :: DOM | eff) Unit
+sendArrayBuffer :: WebSocket -> ArrayBuffer -> Effect Unit
 sendArrayBuffer ws = sendImpl ws <<< toForeign
 
-sendArrayBufferView :: forall t eff. WebSocket -> ArrayView t -> Eff (dom :: DOM | eff) Unit
+sendArrayBufferView :: forall t. WebSocket -> ArrayView t -> Effect Unit
 sendArrayBufferView ws = sendImpl ws <<< toForeign


### PR DESCRIPTION
In furtherance of #93 I've swapped out `Eff` for [`Effect`](https://github.com/purescript/purescript-effect). Once this PR is merge (in the not too distant future :pray:) work can being on breaking the non-DOM related web APIs out into their own packages.

Everything builds, but there's a transitive dependency on `Aff` via https://github.com/bodil/purescript-test-unit.

Until `Aff` (and then `Test.Unit`) is updated to use `Effect` or a test library not reliant on `Aff` replaces it, a merge is not possible.