### PR TITLE
Add HTMLHyperlinkElementUtils.

### DIFF
--- a/src/DOM/HTML/HTMLHyperlinkElementUtils.js
+++ b/src/DOM/HTML/HTMLHyperlinkElementUtils.js
@@ -1,0 +1,167 @@
+"use strict";
+
+exports.href = function (u) {
+  return function () {
+    return u.href;
+  };
+};
+
+exports.setHref = function (href) {
+  return function (u) {
+    return function () {
+      u.href = href;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.origin = function (u) {
+  return function () {
+    return u.origin;
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.protocol = function (u) {
+  return function () {
+    return u.protocol;
+  };
+};
+
+exports.setProtocol = function (protocol) {
+  return function (u) {
+    return function () {
+      u.protocol = protocol;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.username = function (u) {
+  return function () {
+    return u.username;
+  };
+};
+
+exports.setUsername = function (username) {
+  return function (u) {
+    return function () {
+      u.username = username;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.password = function (u) {
+  return function () {
+    return u.password;
+  };
+};
+
+exports.setPassword = function (password) {
+  return function (u) {
+    return function () {
+      u.password = password;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.host = function (u) {
+  return function () {
+    return u.host;
+  };
+};
+
+exports.setHost = function (host) {
+  return function (u) {
+    return function () {
+      u.host = host;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.hostname = function (u) {
+  return function () {
+    return u.hostname;
+  };
+};
+
+exports.setHostname = function (hostname) {
+  return function (u) {
+    return function () {
+      u.hostname = hostname;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.port = function (u) {
+  return function () {
+    return u.port;
+  };
+};
+
+exports.setPort = function (port) {
+  return function (u) {
+    return function () {
+      u.port = port;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.pathname = function (u) {
+  return function () {
+    return u.pathname;
+  };
+};
+
+exports.setPathname = function (pathname) {
+  return function (u) {
+    return function () {
+      u.pathname = pathname;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.search = function (u) {
+  return function () {
+    return u.search;
+  };
+};
+
+exports.setSearch = function (search) {
+  return function (u) {
+    return function () {
+      u.search = search;
+    };
+  };
+};
+
+// ----------------------------------------------------------------------------
+
+exports.hash = function (u) {
+  return function () {
+    return u.hash;
+  };
+};
+
+exports.setHash = function (hash) {
+  return function (u) {
+    return function () {
+      u.hash = hash;
+    };
+  };
+};

--- a/src/DOM/HTML/HTMLHyperlinkElementUtils.purs
+++ b/src/DOM/HTML/HTMLHyperlinkElementUtils.purs
@@ -1,0 +1,41 @@
+-- https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils
+module DOM.HTML.HTMLHyperlinkElementUtils where
+
+import Prelude (Unit)
+
+import Control.Monad.Eff (Eff)
+
+import DOM (DOM)
+import DOM.HTML.Types (HTMLHyperlinkElementUtils)
+
+foreign import href :: forall eff. HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) String
+foreign import setHref :: forall eff. String -> HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) Unit
+
+foreign import origin :: forall eff. HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) String
+
+foreign import protocol :: forall eff. HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) String
+foreign import setProtocol :: forall eff. String -> HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) Unit
+
+foreign import username :: forall eff. HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) String
+foreign import setUsername :: forall eff. String -> HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) Unit
+
+foreign import password :: forall eff. HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) String
+foreign import setPassword :: forall eff. String -> HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) Unit
+
+foreign import host :: forall eff. HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) String
+foreign import setHost :: forall eff. String -> HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) Unit
+
+foreign import hostname :: forall eff. HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) String
+foreign import setHostname :: forall eff. String -> HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) Unit
+
+foreign import port :: forall eff. HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) String
+foreign import setPort :: forall eff. String -> HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) Unit
+
+foreign import pathname :: forall eff. HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) String
+foreign import setPathname :: forall eff. String -> HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) Unit
+
+foreign import search :: forall eff. HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) String
+foreign import setSearch :: forall eff. String -> HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) Unit
+
+foreign import hash :: forall eff. HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) String
+foreign import setHash :: forall eff. String -> HTMLHyperlinkElementUtils -> Eff (dom :: DOM | eff) Unit

--- a/src/DOM/HTML/HTMLHyperlinkElementUtils.purs
+++ b/src/DOM/HTML/HTMLHyperlinkElementUtils.purs
@@ -1,4 +1,5 @@
--- https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils
+-- The `URLUtils` interface, referenced in https://www.w3.org/TR/html50/infrastructure.html#urlutils
+--   now documented at https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils
 module DOM.HTML.HTMLHyperlinkElementUtils where
 
 import Prelude (Unit)

--- a/src/DOM/HTML/Types.purs
+++ b/src/DOM/HTML/Types.purs
@@ -82,6 +82,8 @@ module DOM.HTML.Types
   , HTMLAnchorElement
   , htmlAnchorElementToHTMLElement
   , readHTMLAnchorElement
+  , HTMLHyperlinkElementUtils
+  , htmlAnchorElementToHTMLHyperlinkElementUtils
   , HTMLDataElement
   , htmlDataElementToHTMLElement
   , readHTMLDataElement
@@ -456,6 +458,11 @@ htmlAnchorElementToHTMLElement = U.unsafeCoerce
 
 readHTMLAnchorElement :: Foreign -> F HTMLAnchorElement
 readHTMLAnchorElement = unsafeReadTagged "HTMLAnchorElement"
+
+foreign import data HTMLHyperlinkElementUtils :: Type
+
+htmlAnchorElementToHTMLHyperlinkElementUtils :: HTMLAnchorElement -> HTMLHyperlinkElementUtils
+htmlAnchorElementToHTMLHyperlinkElementUtils = U.unsafeCoerce
 
 foreign import data HTMLDataElement :: Type
 


### PR DESCRIPTION
https://github.com/purescript-web/purescript-dom/issues/143

This API is required to get the `href` attribute from an anchor element. I just threw this together to get a concrete proposal for this. I think it's working in my experiment project.